### PR TITLE
Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+# Top level.
+include *.rst
+
+exclude *.png
+
+# Non-python files.
+recursive-include sphinx_rtd_theme *
+recursive-exclude sass *
+
+# Extraneous files.
+global-exclude .DS_Store
+global-exclude *.pyc

--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,34 @@ if you're just trying to use it on your project outside of that site.
 Installation
 ============
 
+Via package
+-----------
+
+Download the package or add it to your ``requirements.txt`` file:
+
+.. code-block:: bash
+
+    $ pip install -e git+git://github.com/tony/sphinx_rtd_theme@pypi#egg=sphinx_rtd_theme
+
+In your ``conf.py`` file:
+
+.. code-block:: python
+
+    import sphinx_rtd_theme
+
+    html_theme = "sphinx_rtd_theme"
+
+    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
+
+Via git or download
+-------------------
+
+
 Symlink or subtree the ``sphinx_rtd_theme/sphinx_rtd_theme`` repository into your documentation at
 ``docs/_themes/sphinx_rtd_theme`` then add the following two settings to your Sphinx
 conf.py file:
 
-.. code-block::
+.. code-block:: python
 
     html_theme = "sphinx_rtd_theme"
     html_theme_path = ["_themes", ]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""`sphinxcontrib-rtd_theme` lives on `Github`_.
+
+.. _github: https://www.github.com/snide/sphinx_rtd_theme
+
+"""
+from setuptools import setup, find_packages
+from sphinx_rtd_theme import __version__
+
+try:
+    from pip.req import parse_requirements
+except ImportError:
+    def requirements(f):
+        reqs = open(f, 'r').read().splitlines()
+        reqs = [r for r in reqs if not r.strip().startswith('#')]
+        return reqs
+else:
+    def requirements(f):
+        install_reqs = parse_requirements(f)
+        reqs = [str(r.req) for r in install_reqs]
+        return reqs
+
+
+setup(
+    name='sphinxcontrib_rtd_theme',
+    version=__version__,
+    url='https://github.com/snide/sphinx_rtd_theme/',
+    license='MIT',
+    author='Dave Snider',
+    author_email='dave.snider@gmail.com',
+    description='ReadTheDocs.org theme for Sphinx, 2013 version.',
+    long_description=open('README.rst').read(),
+    zip_safe=False,
+    packages=find_packages(),
+    package_data = { "sphinx_rtd_theme": ['*.*', 'static/*.*', 'static/*/*.*'] },
+    install_requires=['sphinx>=1.1'],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'License :: OSI Approved :: BSD License',
+        'Environment :: Console',
+        'Environment :: Web Environment',
+        'Intended Audience :: Developers',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Operating System :: OS Independent',
+        'Topic :: Documentation',
+        'Topic :: Software Development :: Documentation',
+    ],
+)

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -1,0 +1,17 @@
+"""Sphinx ReadTheDocs theme.
+
+From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
+
+"""
+import os
+
+VERSION = (0, 1, 0)
+
+__version__ = ".".join(str(v) for v in VERSION)
+__version_full__ = __version__
+
+
+def get_html_theme_path():
+    """Return list of HTML theme paths."""
+    cur_dir = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+    return cur_dir


### PR DESCRIPTION
Re: #13

Testing at http://tmuxp.readthedocs.org/en/latest/ (https://github.com/tony/tmuxp/blob/master/doc/requirements.pip)

I believe that @ericholscher will be doing the pypi, so we need communication for how to test this.

Unlike [sphinx-contrib](https://bitbucket.org/birkenfeld/sphinx-contrib/) extensions, themes don't have a best practice. So I'm playing by observation and practicality:

For a python package, I looked at https://github.com/ryan-roemer/sphinx-bootstrap-theme's `__init__.py`. Sphinx-boot-strap themes, and other newer sphinx themes, including https://bitbucket.org/ecollins/cloud_sptheme, let the package assist with the `html_theme_path` by providing a function.

Bike-shedding: I think it's best to let the method return a string to be placed _inside_ a theme path list. The path is one of many, and people unfamiliar with sphinx would otherwise have to assume that `html_theme_path` is a list and `.append` it.
