### PR TITLE
New demo content, sass fixes for inline code, autodoc code. Styling for code.

### DIFF
--- a/demo_docs/source/index.rst
+++ b/demo_docs/source/index.rst
@@ -60,6 +60,27 @@ The first hexagram is made up of six unbroken lines. These unbroken lines stand 
 
 The power represented by the hexagram is to be interpreted in a dual sense in terms of its action on the universe and of its action on the world of men. In relation to the universe, the hexagram expresses the strong, creative action of the Deity. In relation to the human world, it denotes the creative action of the holy man or sage, of the ruler or leader of men, who through his power awakens and develops their higher nature.
 
+Inline code and references
+==========================
+
+`reStructuredText`_ is a markup language. It can use roles and
+declarations to turn reST into HTML.
+
+In reST, ``*hello world*`` becomes ``<em>hello world</em>``. This is
+because a library called `Docutils`_ was able to parse the reST and use a
+``Writer`` to output it that way.
+
+If I type ````an inline literal```` it will wrap it in ``<tt>``. You can
+see more details on the `Inline Markup`_ on the Docutils homepage.
+
+Also with ``sphinx.ext.autodoc``, which I use in the demo, I can link to
+:class:`test_py_module.test.Foo`. It will link you right my code
+documentation for it.
+
+.. _reStructuredText: http://docutils.sourceforge.net/rst.html
+.. _Docutils: http://docutils.sourceforge.net/
+.. _Inline Markup: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#inline-markup
+
 Citation
 ========
 

--- a/demo_docs/source/test_py_module/test.py
+++ b/demo_docs/source/test_py_module/test.py
@@ -1,7 +1,31 @@
 # -*- coding: utf-8 -*-
+"""Test Module for sphinx_rtd_theme."""
 
 class Foo:
-    """Docstring for class Foo."""
+
+    r"""Docstring for class Foo.
+
+    This text tests for the formatting of docstrings generated from output
+    ``sphinx.ext.autodoc``. Which contain reST, but sphinx nests it in the
+    ``<dl>``, and ``<dt>`` tags. Also, ``<tt>`` is used for class, method names
+    and etc, but those will *always* have the ``.descname`` or
+    ``.descclassname`` class.
+
+    Normal ``<tt>`` (like the <tt> I just wrote here) needs to be shown with
+    the same style as anything else with ````this type of markup````.
+
+    It's common for programmers to give a code example inside of their
+    docstring::
+
+        from test_py_module import Foo
+
+        myclass = Foo()
+        myclass.dothismethod('with this argument')
+        myclass.flush()
+
+        print(myclass)
+
+    """
 
     #: Doc comment for class attribute Foo.bar.
     #: It can have multiple lines.

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -108,12 +108,12 @@
     .field-body
       text-align: left
       padding-left: 0
+  // This is seen in sphinx.ext.autodoc output
   dl
     dt
-      @extend code
       display: inline-block
       margin: $base-line-height / 4 0
-      font-size: 80%
+      font-size: 90%
       line-height: normal
       background: $gray-lighter
       color: $gray-dark
@@ -123,33 +123,60 @@
       .headerlink
         color: $text-color
         font-size: 100% !important
-      .descname, .descclassname, big, em
-        font-size: 100% !important
-        line-height: normal
+
+
     dt:first-child
       margin-top: 0
     dd
       margin-left: $base-line-height
 
+    tt // for sphinx.ext.autodoc generated content
+      &.descname, &.descclassname
+        background-color: transparent
+        border: none
+        padding: 0
+        font-size: 100% !important
+      &.descname
+        font-weight: bold
+
   dl dl
     dt
-      @extend code
       display: inline-block
       margin-bottom: $base-line-height / 4
-      font-size: 80%
-      line-height: normal
+      font-size: 90%
+      background: none
+      border: none
+
       .headerlink
         color: $text-color
         font-size: 100% !important
+
+  // reST for ``inline code`` statements
+  // This does a few things to make inline code easier to read
+  // Even though the font size of $code-font-family is same as normal font
+  // it looks huge compared to it, so lets trial with it @ 90%.
   tt
+    white-space: nowrap
+    max-width: 100%
+    background: $white
+    border: solid 1px $table-border-color
+    color: $text-color
+    font-size: 80%
+    padding: 0 5px
     font-family: $code-font-family
-    &.literal
-      @extend code
+    overflow-x: auto
+
+    big, em
+      font-size: 100% !important
+      line-height: normal
+
+    .xref, a &
+      font-weight: bold
+
   blockquote
     margin-left: $base-line-height
     line-height: $base-line-height
     margin-bottom: $base-line-height
-
 
   #search-results
     .search li

--- a/sphinx_rtd_theme/static/css/badge_only.css
+++ b/sphinx_rtd_theme/static/css/badge_only.css
@@ -1,1 +1,236 @@
-*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.font-smooth,.icon:before{-webkit-font-smoothing:antialiased}.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:""}.clearfix:after{clear:both}@font-face{font-family:fontawesome-webfont;font-weight:normal;font-style:normal;src:url("../font/fontawesome_webfont.eot");src:url("../font/fontawesome_webfont.eot?#iefix") format("embedded-opentype"),url("../font/fontawesome_webfont.woff") format("woff"),url("../font/fontawesome_webfont.ttf") format("truetype"),url("../font/fontawesome_webfont.svg#fontawesome-webfont") format("svg")}.icon:before{display:inline-block;font-family:fontawesome-webfont;font-style:normal;font-weight:normal;line-height:1;text-decoration:inherit}a .icon{display:inline-block;text-decoration:inherit}li .icon{display:inline-block}li .icon-large:before,li .icon-large:before{width:1.875em}ul.icons{list-style-type:none;margin-left:2em;text-indent:-0.8em}ul.icons li .icon{width:0.8em}ul.icons li .icon-large:before,ul.icons li .icon-large:before{vertical-align:baseline}.icon-book:before{content:"\f02d"}.icon-caret-down:before{content:"\f0d7"}.icon-caret-up:before{content:"\f0d8"}.icon-caret-left:before{content:"\f0d9"}.icon-caret-right:before{content:"\f0da"}.rst-versions{position:fixed;bottom:0;left:0;width:300px;color:#fcfcfc;background:#1f1d1d;border-top:solid 10px #343131;font-family:"Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;z-index:400}.rst-versions a{color:#2980b9;text-decoration:none}.rst-versions .rst-badge-small{display:none}.rst-versions .rst-current-version{padding:12px;background-color:#272525;display:block;text-align:right;font-size:90%;cursor:pointer;color:#27ae60;*zoom:1}.rst-versions .rst-current-version:before,.rst-versions .rst-current-version:after{display:table;content:""}.rst-versions .rst-current-version:after{clear:both}.rst-versions .rst-current-version .icon{color:#fcfcfc}.rst-versions .rst-current-version .icon-book{float:left}.rst-versions .rst-current-version.rst-out-of-date{background-color:#e74c3c;color:#fff}.rst-versions.shift-up .rst-other-versions{display:block}.rst-versions .rst-other-versions{font-size:90%;padding:12px;color:gray;display:none}.rst-versions .rst-other-versions hr{display:block;height:1px;border:0;margin:20px 0;padding:0;border-top:solid 1px #413d3d}.rst-versions .rst-other-versions dd{display:inline-block;margin:0}.rst-versions .rst-other-versions dd a{display:inline-block;padding:6px;color:#fcfcfc}.rst-versions.rst-badge{width:auto;bottom:20px;right:20px;left:auto;border:none;max-width:300px}.rst-versions.rst-badge .icon-book{float:none}.rst-versions.rst-badge.shift-up .rst-current-version{text-align:right}.rst-versions.rst-badge.shift-up .rst-current-version .icon-book{float:left}.rst-versions.rst-badge .rst-current-version{width:auto;height:30px;line-height:30px;padding:0 6px;display:block;text-align:center}@media screen and (max-width: 768px){.rst-versions{width:85%;display:none}.rst-versions.shift{display:block}img{width:100%;height:auto}}
+/* line 2, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_grid.scss */
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 70, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.font-smooth, .icon:before {
+  -webkit-font-smoothing: antialiased;
+}
+
+/* line 124, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix {
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix:before, .clearfix:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix:after {
+  clear: both;
+}
+
+@font-face {
+  font-family: fontawesome-webfont;
+  font-weight: normal;
+  font-style: normal;
+  src: url("../font/fontawesome_webfont.eot");
+  src: url("../font/fontawesome_webfont.eot?#iefix") format("embedded-opentype"), url("../font/fontawesome_webfont.woff") format("woff"), url("../font/fontawesome_webfont.ttf") format("truetype"), url("../font/fontawesome_webfont.svg#fontawesome-webfont") format("svg");
+}
+
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon:before {
+  display: inline-block;
+  font-family: fontawesome-webfont;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  text-decoration: inherit;
+}
+
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+a .icon {
+  display: inline-block;
+  text-decoration: inherit;
+}
+
+/* line 20, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+li .icon {
+  display: inline-block;
+}
+/* line 22, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+li .icon-large:before,
+li .icon-large:before {
+  /* 1.5 increased font size for icon-large * 1.25 width */
+  width: 1.875em;
+}
+
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+ul.icons {
+  list-style-type: none;
+  margin-left: 2em;
+  text-indent: -0.8em;
+}
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+ul.icons li .icon {
+  width: 0.8em;
+}
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+ul.icons li .icon-large:before,
+ul.icons li .icon-large:before {
+  /* 1.5 increased font size for icon-large * 1.25 width */
+  vertical-align: baseline;
+}
+
+/* line 40, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon-book:before {
+  content: "\f02d";
+}
+
+/* line 43, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon-caret-down:before {
+  content: "\f0d7";
+}
+
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon-caret-up:before {
+  content: "\f0d8";
+}
+
+/* line 49, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon-caret-left:before {
+  content: "\f0d9";
+}
+
+/* line 52, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge_fa.sass */
+.icon-caret-right:before {
+  content: "\f0da";
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 300px;
+  color: #fcfcfc;
+  background: #1f1d1d;
+  border-top: solid 10px #343131;
+  font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+  z-index: 400;
+}
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions a {
+  color: #2980b9;
+  text-decoration: none;
+}
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-badge-small {
+  display: none;
+}
+/* line 16, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version {
+  padding: 12px;
+  background-color: #272525;
+  display: block;
+  text-align: right;
+  font-size: 90%;
+  cursor: pointer;
+  color: #27ae60;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-versions .rst-current-version:before, .rst-versions .rst-current-version:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-versions .rst-current-version:after {
+  clear: both;
+}
+/* line 25, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version .icon {
+  color: #fcfcfc;
+}
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version .icon-book {
+  float: left;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version.rst-out-of-date {
+  background-color: #e74c3c;
+  color: white;
+}
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.shift-up .rst-other-versions {
+  display: block;
+}
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions {
+  font-size: 90%;
+  padding: 12px;
+  color: gray;
+  display: none;
+}
+/* line 39, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  margin: 20px 0;
+  padding: 0;
+  border-top: solid 1px #413d3d;
+}
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions dd {
+  display: inline-block;
+  margin: 0;
+}
+/* line 49, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions dd a {
+  display: inline-block;
+  padding: 6px;
+  color: #fcfcfc;
+}
+/* line 53, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge {
+  width: auto;
+  bottom: 20px;
+  right: 20px;
+  left: auto;
+  border: none;
+  max-width: 300px;
+}
+/* line 60, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge .icon-book {
+  float: none;
+}
+/* line 62, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge.shift-up .rst-current-version {
+  text-align: right;
+}
+/* line 64, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge.shift-up .rst-current-version .icon-book {
+  float: left;
+}
+/* line 66, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge .rst-current-version {
+  width: auto;
+  height: 30px;
+  line-height: 30px;
+  padding: 0 6px;
+  display: block;
+  text-align: center;
+}
+
+@media screen and (max-width: 768px) {
+  /* line 75, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  .rst-versions {
+    width: 85%;
+    display: none;
+  }
+  /* line 78, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  .rst-versions.shift {
+    display: block;
+  }
+
+  /* line 80, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  img {
+    width: 100%;
+    height: auto;
+  }
+}

--- a/sphinx_rtd_theme/static/css/theme.css
+++ b/sphinx_rtd_theme/static/css/theme.css
@@ -1,1 +1,5248 @@
-*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}article,aside,details,figcaption,figure,footer,header,hgroup,nav,section{display:block}audio,canvas,video{display:inline-block;*display:inline;*zoom:1}audio:not([controls]){display:none}[hidden]{display:none}*{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}html{font-size:100%;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%}body{margin:0}a:hover,a:active{outline:0}abbr[title]{border-bottom:1px dotted}b,strong{font-weight:bold}blockquote{margin:0}dfn{font-style:italic}hr{display:block;height:1px;border:0;border-top:1px solid #ccc;margin:20px 0;padding:0}ins{background:#ff9;color:#000;text-decoration:none}mark{background:#ff0;color:#000;font-style:italic;font-weight:bold}pre,code,.rst-content dl dt,.rst-content dl dl dt,.rst-content tt.literal,kbd,samp{font-family:monospace,serif;_font-family:"courier new",monospace;font-size:1em}pre{white-space:pre}q{quotes:none}q:before,q:after{content:"";content:none}small{font-size:85%}sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}sup{top:-0.5em}sub{bottom:-0.25em}ul,ol,dl{margin:0;padding:0;list-style:none;list-style-image:none}li{list-style:none}dd{margin:0}img{border:0;-ms-interpolation-mode:bicubic;vertical-align:middle;max-width:100%}svg:not(:root){overflow:hidden}figure{margin:0}form{margin:0}fieldset{border:0;margin:0;padding:0}label{cursor:pointer}legend{border:0;*margin-left:-7px;padding:0;white-space:normal}button,input,select,textarea{font-size:100%;margin:0;vertical-align:baseline;*vertical-align:middle}button,input{line-height:normal}button,input[type="button"],input[type="reset"],input[type="submit"]{cursor:pointer;-webkit-appearance:button;*overflow:visible}button[disabled],input[disabled]{cursor:default}input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0;*width:13px;*height:13px}input[type="search"]{-webkit-appearance:textfield;-moz-box-sizing:content-box;-webkit-box-sizing:content-box;box-sizing:content-box}input[type="search"]::-webkit-search-decoration,input[type="search"]::-webkit-search-cancel-button{-webkit-appearance:none}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}textarea{overflow:auto;vertical-align:top;resize:vertical}table{border-collapse:collapse;border-spacing:0}td{vertical-align:top}.chromeframe{margin:0.2em 0;background:#ccc;color:#000;padding:0.2em 0}.ir{display:block;border:0;text-indent:-999em;overflow:hidden;background-color:transparent;background-repeat:no-repeat;text-align:left;direction:ltr;*line-height:0}.ir br{display:none}.hidden{display:none !important;visibility:hidden}.visuallyhidden{border:0;clip:rect(0 0 0 0);height:1px;margin:-1px;overflow:hidden;padding:0;position:absolute;width:1px}.visuallyhidden.focusable:active,.visuallyhidden.focusable:focus{clip:auto;height:auto;margin:0;overflow:visible;position:static;width:auto}.invisible{visibility:hidden}.relative{position:relative}big,small{font-size:100%}@media print{html,body,section{background:none !important}*{box-shadow:none !important;text-shadow:none !important;filter:none !important;-ms-filter:none !important}a,a:visited{text-decoration:underline}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h2,h3{page-break-after:avoid}}.font-smooth,.icon:before,.wy-inline-validate.wy-inline-validate-success .wy-input-context:before,.wy-inline-validate.wy-inline-validate-danger .wy-input-context:before,.wy-inline-validate.wy-inline-validate-warning .wy-input-context:before,.wy-inline-validate.wy-inline-validate-info .wy-input-context:before,.wy-tag-input-group .wy-tag .wy-tag-remove:before,.rst-content .admonition-title:before,.rst-content h1 .headerlink:before,.rst-content h2 .headerlink:before,.rst-content h3 .headerlink:before,.rst-content h4 .headerlink:before,.rst-content h5 .headerlink:before,.rst-content h6 .headerlink:before,.rst-content dl dt .headerlink:before,.wy-alert,.rst-content .note,.rst-content .attention,.rst-content .caution,.rst-content .danger,.rst-content .error,.rst-content .hint,.rst-content .important,.rst-content .tip,.rst-content .warning,.btn,input[type="text"],input[type="password"],input[type="email"],input[type="url"],input[type="date"],input[type="month"],input[type="time"],input[type="datetime"],input[type="datetime-local"],input[type="week"],input[type="number"],input[type="search"],input[type="tel"],input[type="color"],select,textarea,.wy-tag-input-group,.wy-menu-vertical li.on a,.wy-menu-vertical li.current>a,.wy-side-nav-search>a,.wy-side-nav-search .wy-dropdown>a,.wy-nav-top a{-webkit-font-smoothing:antialiased}.clearfix{*zoom:1}.clearfix:before,.clearfix:after{display:table;content:""}.clearfix:after{clear:both}@font-face{font-family:fontawesome-webfont;font-weight:normal;font-style:normal;src:url("../font/fontawesome_webfont.eot");src:url("../font/fontawesome_webfont.eot?#iefix") format("embedded-opentype"),url("../font/fontawesome_webfont.woff") format("woff"),url("../font/fontawesome_webfont.ttf") format("truetype"),url("../font/fontawesome_webfont.svg#fontawesome-webfont") format("svg")}.icon:before,.wy-inline-validate.wy-inline-validate-success .wy-input-context:before,.wy-inline-validate.wy-inline-validate-danger .wy-input-context:before,.wy-inline-validate.wy-inline-validate-warning .wy-input-context:before,.wy-inline-validate.wy-inline-validate-info .wy-input-context:before,.wy-tag-input-group .wy-tag .wy-tag-remove:before,.rst-content .admonition-title:before,.rst-content h1 .headerlink:before,.rst-content h2 .headerlink:before,.rst-content h3 .headerlink:before,.rst-content h4 .headerlink:before,.rst-content h5 .headerlink:before,.rst-content h6 .headerlink:before,.rst-content dl dt .headerlink:before{display:inline-block;font-family:fontawesome-webfont;font-style:normal;font-weight:normal;line-height:1;text-decoration:inherit}a .icon,a .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success a .wy-input-context,a .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger a .wy-input-context,a .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning a .wy-input-context,a .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info a .wy-input-context,a .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag a .wy-tag-remove,a .rst-content .admonition-title,.rst-content a .admonition-title,a .rst-content h1 .headerlink,.rst-content h1 a .headerlink,a .rst-content h2 .headerlink,.rst-content h2 a .headerlink,a .rst-content h3 .headerlink,.rst-content h3 a .headerlink,a .rst-content h4 .headerlink,.rst-content h4 a .headerlink,a .rst-content h5 .headerlink,.rst-content h5 a .headerlink,a .rst-content h6 .headerlink,.rst-content h6 a .headerlink,a .rst-content dl dt .headerlink,.rst-content dl dt a .headerlink{display:inline-block;text-decoration:inherit}.icon-large:before{vertical-align:-10%;font-size:1.33333em}.btn .icon,.btn .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success .btn .wy-input-context,.btn .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger .btn .wy-input-context,.btn .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning .btn .wy-input-context,.btn .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info .btn .wy-input-context,.btn .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag .btn .wy-tag-remove,.btn .rst-content .admonition-title,.rst-content .btn .admonition-title,.btn .rst-content h1 .headerlink,.rst-content h1 .btn .headerlink,.btn .rst-content h2 .headerlink,.rst-content h2 .btn .headerlink,.btn .rst-content h3 .headerlink,.rst-content h3 .btn .headerlink,.btn .rst-content h4 .headerlink,.rst-content h4 .btn .headerlink,.btn .rst-content h5 .headerlink,.rst-content h5 .btn .headerlink,.btn .rst-content h6 .headerlink,.rst-content h6 .btn .headerlink,.btn .rst-content dl dt .headerlink,.rst-content dl dt .btn .headerlink,.nav .icon,.nav .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success .nav .wy-input-context,.nav .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger .nav .wy-input-context,.nav .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning .nav .wy-input-context,.nav .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info .nav .wy-input-context,.nav .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag .nav .wy-tag-remove,.nav .rst-content .admonition-title,.rst-content .nav .admonition-title,.nav .rst-content h1 .headerlink,.rst-content h1 .nav .headerlink,.nav .rst-content h2 .headerlink,.rst-content h2 .nav .headerlink,.nav .rst-content h3 .headerlink,.rst-content h3 .nav .headerlink,.nav .rst-content h4 .headerlink,.rst-content h4 .nav .headerlink,.nav .rst-content h5 .headerlink,.rst-content h5 .nav .headerlink,.nav .rst-content h6 .headerlink,.rst-content h6 .nav .headerlink,.nav .rst-content dl dt .headerlink,.rst-content dl dt .nav .headerlink{display:inline}.btn .icon.icon-large,.btn .wy-inline-validate.wy-inline-validate-success .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-success .btn .icon-large.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-danger .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-danger .btn .icon-large.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-warning .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-warning .btn .icon-large.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-info .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-info .btn .icon-large.wy-input-context,.btn .wy-tag-input-group .wy-tag .icon-large.wy-tag-remove,.wy-tag-input-group .wy-tag .btn .icon-large.wy-tag-remove,.btn .rst-content .icon-large.admonition-title,.rst-content .btn .icon-large.admonition-title,.btn .rst-content h1 .icon-large.headerlink,.rst-content h1 .btn .icon-large.headerlink,.btn .rst-content h2 .icon-large.headerlink,.rst-content h2 .btn .icon-large.headerlink,.btn .rst-content h3 .icon-large.headerlink,.rst-content h3 .btn .icon-large.headerlink,.btn .rst-content h4 .icon-large.headerlink,.rst-content h4 .btn .icon-large.headerlink,.btn .rst-content h5 .icon-large.headerlink,.rst-content h5 .btn .icon-large.headerlink,.btn .rst-content h6 .icon-large.headerlink,.rst-content h6 .btn .icon-large.headerlink,.btn .rst-content dl dt .icon-large.headerlink,.rst-content dl dt .btn .icon-large.headerlink,.nav .icon.icon-large,.nav .wy-inline-validate.wy-inline-validate-success .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-success .nav .icon-large.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-danger .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-danger .nav .icon-large.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-warning .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-warning .nav .icon-large.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-info .icon-large.wy-input-context,.wy-inline-validate.wy-inline-validate-info .nav .icon-large.wy-input-context,.nav .wy-tag-input-group .wy-tag .icon-large.wy-tag-remove,.wy-tag-input-group .wy-tag .nav .icon-large.wy-tag-remove,.nav .rst-content .icon-large.admonition-title,.rst-content .nav .icon-large.admonition-title,.nav .rst-content h1 .icon-large.headerlink,.rst-content h1 .nav .icon-large.headerlink,.nav .rst-content h2 .icon-large.headerlink,.rst-content h2 .nav .icon-large.headerlink,.nav .rst-content h3 .icon-large.headerlink,.rst-content h3 .nav .icon-large.headerlink,.nav .rst-content h4 .icon-large.headerlink,.rst-content h4 .nav .icon-large.headerlink,.nav .rst-content h5 .icon-large.headerlink,.rst-content h5 .nav .icon-large.headerlink,.nav .rst-content h6 .icon-large.headerlink,.rst-content h6 .nav .icon-large.headerlink,.nav .rst-content dl dt .icon-large.headerlink,.rst-content dl dt .nav .icon-large.headerlink{line-height:0.9em}.btn .icon.icon-spin,.btn .wy-inline-validate.wy-inline-validate-success .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-success .btn .icon-spin.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-danger .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-danger .btn .icon-spin.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-warning .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-warning .btn .icon-spin.wy-input-context,.btn .wy-inline-validate.wy-inline-validate-info .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-info .btn .icon-spin.wy-input-context,.btn .wy-tag-input-group .wy-tag .icon-spin.wy-tag-remove,.wy-tag-input-group .wy-tag .btn .icon-spin.wy-tag-remove,.btn .rst-content .icon-spin.admonition-title,.rst-content .btn .icon-spin.admonition-title,.btn .rst-content h1 .icon-spin.headerlink,.rst-content h1 .btn .icon-spin.headerlink,.btn .rst-content h2 .icon-spin.headerlink,.rst-content h2 .btn .icon-spin.headerlink,.btn .rst-content h3 .icon-spin.headerlink,.rst-content h3 .btn .icon-spin.headerlink,.btn .rst-content h4 .icon-spin.headerlink,.rst-content h4 .btn .icon-spin.headerlink,.btn .rst-content h5 .icon-spin.headerlink,.rst-content h5 .btn .icon-spin.headerlink,.btn .rst-content h6 .icon-spin.headerlink,.rst-content h6 .btn .icon-spin.headerlink,.btn .rst-content dl dt .icon-spin.headerlink,.rst-content dl dt .btn .icon-spin.headerlink,.nav .icon.icon-spin,.nav .wy-inline-validate.wy-inline-validate-success .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-success .nav .icon-spin.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-danger .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-danger .nav .icon-spin.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-warning .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-warning .nav .icon-spin.wy-input-context,.nav .wy-inline-validate.wy-inline-validate-info .icon-spin.wy-input-context,.wy-inline-validate.wy-inline-validate-info .nav .icon-spin.wy-input-context,.nav .wy-tag-input-group .wy-tag .icon-spin.wy-tag-remove,.wy-tag-input-group .wy-tag .nav .icon-spin.wy-tag-remove,.nav .rst-content .icon-spin.admonition-title,.rst-content .nav .icon-spin.admonition-title,.nav .rst-content h1 .icon-spin.headerlink,.rst-content h1 .nav .icon-spin.headerlink,.nav .rst-content h2 .icon-spin.headerlink,.rst-content h2 .nav .icon-spin.headerlink,.nav .rst-content h3 .icon-spin.headerlink,.rst-content h3 .nav .icon-spin.headerlink,.nav .rst-content h4 .icon-spin.headerlink,.rst-content h4 .nav .icon-spin.headerlink,.nav .rst-content h5 .icon-spin.headerlink,.rst-content h5 .nav .icon-spin.headerlink,.nav .rst-content h6 .icon-spin.headerlink,.rst-content h6 .nav .icon-spin.headerlink,.nav .rst-content dl dt .icon-spin.headerlink,.rst-content dl dt .nav .icon-spin.headerlink{display:inline-block}.btn.icon:before,.wy-inline-validate.wy-inline-validate-success .btn.wy-input-context:before,.wy-inline-validate.wy-inline-validate-danger .btn.wy-input-context:before,.wy-inline-validate.wy-inline-validate-warning .btn.wy-input-context:before,.wy-inline-validate.wy-inline-validate-info .btn.wy-input-context:before,.wy-tag-input-group .wy-tag .btn.wy-tag-remove:before,.rst-content .btn.admonition-title:before,.rst-content h1 .btn.headerlink:before,.rst-content h2 .btn.headerlink:before,.rst-content h3 .btn.headerlink:before,.rst-content h4 .btn.headerlink:before,.rst-content h5 .btn.headerlink:before,.rst-content h6 .btn.headerlink:before,.rst-content dl dt .btn.headerlink:before{opacity:0.5;-webkit-transition:opacity 0.05s ease-in;-moz-transition:opacity 0.05s ease-in;transition:opacity 0.05s ease-in}.btn.icon:hover:before,.wy-inline-validate.wy-inline-validate-success .btn.wy-input-context:hover:before,.wy-inline-validate.wy-inline-validate-danger .btn.wy-input-context:hover:before,.wy-inline-validate.wy-inline-validate-warning .btn.wy-input-context:hover:before,.wy-inline-validate.wy-inline-validate-info .btn.wy-input-context:hover:before,.wy-tag-input-group .wy-tag .btn.wy-tag-remove:hover:before,.rst-content .btn.admonition-title:hover:before,.rst-content h1 .btn.headerlink:hover:before,.rst-content h2 .btn.headerlink:hover:before,.rst-content h3 .btn.headerlink:hover:before,.rst-content h4 .btn.headerlink:hover:before,.rst-content h5 .btn.headerlink:hover:before,.rst-content h6 .btn.headerlink:hover:before,.rst-content dl dt .btn.headerlink:hover:before{opacity:1}.btn-mini .icon:before,.btn-mini .wy-inline-validate.wy-inline-validate-success .wy-input-context:before,.wy-inline-validate.wy-inline-validate-success .btn-mini .wy-input-context:before,.btn-mini .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before,.wy-inline-validate.wy-inline-validate-danger .btn-mini .wy-input-context:before,.btn-mini .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before,.wy-inline-validate.wy-inline-validate-warning .btn-mini .wy-input-context:before,.btn-mini .wy-inline-validate.wy-inline-validate-info .wy-input-context:before,.wy-inline-validate.wy-inline-validate-info .btn-mini .wy-input-context:before,.btn-mini .wy-tag-input-group .wy-tag .wy-tag-remove:before,.wy-tag-input-group .wy-tag .btn-mini .wy-tag-remove:before,.btn-mini .rst-content .admonition-title:before,.rst-content .btn-mini .admonition-title:before,.btn-mini .rst-content h1 .headerlink:before,.rst-content h1 .btn-mini .headerlink:before,.btn-mini .rst-content h2 .headerlink:before,.rst-content h2 .btn-mini .headerlink:before,.btn-mini .rst-content h3 .headerlink:before,.rst-content h3 .btn-mini .headerlink:before,.btn-mini .rst-content h4 .headerlink:before,.rst-content h4 .btn-mini .headerlink:before,.btn-mini .rst-content h5 .headerlink:before,.rst-content h5 .btn-mini .headerlink:before,.btn-mini .rst-content h6 .headerlink:before,.rst-content h6 .btn-mini .headerlink:before,.btn-mini .rst-content dl dt .headerlink:before,.rst-content dl dt .btn-mini .headerlink:before{font-size:14px;vertical-align:-15%}li .icon,li .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success li .wy-input-context,li .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger li .wy-input-context,li .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning li .wy-input-context,li .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info li .wy-input-context,li .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag li .wy-tag-remove,li .rst-content .admonition-title,.rst-content li .admonition-title,li .rst-content h1 .headerlink,.rst-content h1 li .headerlink,li .rst-content h2 .headerlink,.rst-content h2 li .headerlink,li .rst-content h3 .headerlink,.rst-content h3 li .headerlink,li .rst-content h4 .headerlink,.rst-content h4 li .headerlink,li .rst-content h5 .headerlink,.rst-content h5 li .headerlink,li .rst-content h6 .headerlink,.rst-content h6 li .headerlink,li .rst-content dl dt .headerlink,.rst-content dl dt li .headerlink{display:inline-block}li .icon-large:before,li .icon-large:before{width:1.875em}ul.icons{list-style-type:none;margin-left:2em;text-indent:-0.8em}ul.icons li .icon,ul.icons li .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success ul.icons li .wy-input-context,ul.icons li .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger ul.icons li .wy-input-context,ul.icons li .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning ul.icons li .wy-input-context,ul.icons li .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info ul.icons li .wy-input-context,ul.icons li .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag ul.icons li .wy-tag-remove,ul.icons li .rst-content .admonition-title,.rst-content ul.icons li .admonition-title,ul.icons li .rst-content h1 .headerlink,.rst-content h1 ul.icons li .headerlink,ul.icons li .rst-content h2 .headerlink,.rst-content h2 ul.icons li .headerlink,ul.icons li .rst-content h3 .headerlink,.rst-content h3 ul.icons li .headerlink,ul.icons li .rst-content h4 .headerlink,.rst-content h4 ul.icons li .headerlink,ul.icons li .rst-content h5 .headerlink,.rst-content h5 ul.icons li .headerlink,ul.icons li .rst-content h6 .headerlink,.rst-content h6 ul.icons li .headerlink,ul.icons li .rst-content dl dt .headerlink,.rst-content dl dt ul.icons li .headerlink{width:0.8em}ul.icons li .icon-large:before,ul.icons li .icon-large:before{vertical-align:baseline}.icon-glass:before{content:"\f000"}.icon-music:before{content:"\f001"}.icon-search:before{content:"\f002"}.icon-envelope-alt:before{content:"\f003"}.icon-heart:before{content:"\f004"}.icon-star:before{content:"\f005"}.icon-star-empty:before{content:"\f006"}.icon-user:before{content:"\f007"}.icon-film:before{content:"\f008"}.icon-th-large:before{content:"\f009"}.icon-th:before{content:"\f00a"}.icon-th-list:before{content:"\f00b"}.icon-ok:before{content:"\f00c"}.icon-remove:before,.wy-tag-input-group .wy-tag .wy-tag-remove:before{content:"\f00d"}.icon-zoom-in:before{content:"\f00e"}.icon-zoom-out:before{content:"\f010"}.icon-power-off:before,.icon-off:before{content:"\f011"}.icon-signal:before{content:"\f012"}.icon-gear:before,.icon-cog:before{content:"\f013"}.icon-trash:before{content:"\f014"}.icon-home:before{content:"\f015"}.icon-file-alt:before{content:"\f016"}.icon-time:before{content:"\f017"}.icon-road:before{content:"\f018"}.icon-download-alt:before{content:"\f019"}.icon-download:before{content:"\f01a"}.icon-upload:before{content:"\f01b"}.icon-inbox:before{content:"\f01c"}.icon-play-circle:before{content:"\f01d"}.icon-rotate-right:before,.icon-repeat:before{content:"\f01e"}.icon-refresh:before{content:"\f021"}.icon-list-alt:before{content:"\f022"}.icon-lock:before{content:"\f023"}.icon-flag:before{content:"\f024"}.icon-headphones:before{content:"\f025"}.icon-volume-off:before{content:"\f026"}.icon-volume-down:before{content:"\f027"}.icon-volume-up:before{content:"\f028"}.icon-qrcode:before{content:"\f029"}.icon-barcode:before{content:"\f02a"}.icon-tag:before{content:"\f02b"}.icon-tags:before{content:"\f02c"}.icon-book:before{content:"\f02d"}.icon-bookmark:before{content:"\f02e"}.icon-print:before{content:"\f02f"}.icon-camera:before{content:"\f030"}.icon-font:before{content:"\f031"}.icon-bold:before{content:"\f032"}.icon-italic:before{content:"\f033"}.icon-text-height:before{content:"\f034"}.icon-text-width:before{content:"\f035"}.icon-align-left:before{content:"\f036"}.icon-align-center:before{content:"\f037"}.icon-align-right:before{content:"\f038"}.icon-align-justify:before{content:"\f039"}.icon-list:before{content:"\f03a"}.icon-indent-left:before{content:"\f03b"}.icon-indent-right:before{content:"\f03c"}.icon-facetime-video:before{content:"\f03d"}.icon-picture:before{content:"\f03e"}.icon-pencil:before{content:"\f040"}.icon-map-marker:before{content:"\f041"}.icon-adjust:before{content:"\f042"}.icon-tint:before{content:"\f043"}.icon-edit:before{content:"\f044"}.icon-share:before{content:"\f045"}.icon-check:before{content:"\f046"}.icon-move:before{content:"\f047"}.icon-step-backward:before{content:"\f048"}.icon-fast-backward:before{content:"\f049"}.icon-backward:before{content:"\f04a"}.icon-play:before{content:"\f04b"}.icon-pause:before{content:"\f04c"}.icon-stop:before{content:"\f04d"}.icon-forward:before{content:"\f04e"}.icon-fast-forward:before{content:"\f050"}.icon-step-forward:before{content:"\f051"}.icon-eject:before{content:"\f052"}.icon-chevron-left:before{content:"\f053"}.icon-chevron-right:before{content:"\f054"}.icon-plus-sign:before{content:"\f055"}.icon-minus-sign:before{content:"\f056"}.icon-remove-sign:before,.wy-inline-validate.wy-inline-validate-danger .wy-input-context:before{content:"\f057"}.icon-ok-sign:before{content:"\f058"}.icon-question-sign:before{content:"\f059"}.icon-info-sign:before{content:"\f05a"}.icon-screenshot:before{content:"\f05b"}.icon-remove-circle:before{content:"\f05c"}.icon-ok-circle:before{content:"\f05d"}.icon-ban-circle:before{content:"\f05e"}.icon-arrow-left:before{content:"\f060"}.icon-arrow-right:before{content:"\f061"}.icon-arrow-up:before{content:"\f062"}.icon-arrow-down:before{content:"\f063"}.icon-mail-forward:before,.icon-share-alt:before{content:"\f064"}.icon-resize-full:before{content:"\f065"}.icon-resize-small:before{content:"\f066"}.icon-plus:before{content:"\f067"}.icon-minus:before{content:"\f068"}.icon-asterisk:before{content:"\f069"}.icon-exclamation-sign:before,.wy-inline-validate.wy-inline-validate-warning .wy-input-context:before,.wy-inline-validate.wy-inline-validate-info .wy-input-context:before,.rst-content .admonition-title:before{content:"\f06a"}.icon-gift:before{content:"\f06b"}.icon-leaf:before{content:"\f06c"}.icon-fire:before{content:"\f06d"}.icon-eye-open:before{content:"\f06e"}.icon-eye-close:before{content:"\f070"}.icon-warning-sign:before{content:"\f071"}.icon-plane:before{content:"\f072"}.icon-calendar:before{content:"\f073"}.icon-random:before{content:"\f074"}.icon-comment:before{content:"\f075"}.icon-magnet:before{content:"\f076"}.icon-chevron-up:before{content:"\f077"}.icon-chevron-down:before{content:"\f078"}.icon-retweet:before{content:"\f079"}.icon-shopping-cart:before{content:"\f07a"}.icon-folder-close:before{content:"\f07b"}.icon-folder-open:before{content:"\f07c"}.icon-resize-vertical:before{content:"\f07d"}.icon-resize-horizontal:before{content:"\f07e"}.icon-bar-chart:before{content:"\f080"}.icon-twitter-sign:before{content:"\f081"}.icon-facebook-sign:before{content:"\f082"}.icon-camera-retro:before{content:"\f083"}.icon-key:before{content:"\f084"}.icon-gears:before,.icon-cogs:before{content:"\f085"}.icon-comments:before{content:"\f086"}.icon-thumbs-up-alt:before{content:"\f087"}.icon-thumbs-down-alt:before{content:"\f088"}.icon-star-half:before{content:"\f089"}.icon-heart-empty:before{content:"\f08a"}.icon-signout:before{content:"\f08b"}.icon-linkedin-sign:before{content:"\f08c"}.icon-pushpin:before{content:"\f08d"}.icon-external-link:before{content:"\f08e"}.icon-signin:before{content:"\f090"}.icon-trophy:before{content:"\f091"}.icon-github-sign:before{content:"\f092"}.icon-upload-alt:before{content:"\f093"}.icon-lemon:before{content:"\f094"}.icon-phone:before{content:"\f095"}.icon-unchecked:before,.icon-check-empty:before{content:"\f096"}.icon-bookmark-empty:before{content:"\f097"}.icon-phone-sign:before{content:"\f098"}.icon-twitter:before{content:"\f099"}.icon-facebook:before{content:"\f09a"}.icon-github:before{content:"\f09b"}.icon-unlock:before{content:"\f09c"}.icon-credit-card:before{content:"\f09d"}.icon-rss:before{content:"\f09e"}.icon-hdd:before{content:"\f0a0"}.icon-bullhorn:before{content:"\f0a1"}.icon-bell:before{content:"\f0a2"}.icon-certificate:before{content:"\f0a3"}.icon-hand-right:before{content:"\f0a4"}.icon-hand-left:before{content:"\f0a5"}.icon-hand-up:before{content:"\f0a6"}.icon-hand-down:before{content:"\f0a7"}.icon-circle-arrow-left:before{content:"\f0a8"}.icon-circle-arrow-right:before{content:"\f0a9"}.icon-circle-arrow-up:before{content:"\f0aa"}.icon-circle-arrow-down:before{content:"\f0ab"}.icon-globe:before{content:"\f0ac"}.icon-wrench:before{content:"\f0ad"}.icon-tasks:before{content:"\f0ae"}.icon-filter:before{content:"\f0b0"}.icon-briefcase:before{content:"\f0b1"}.icon-fullscreen:before{content:"\f0b2"}.icon-group:before{content:"\f0c0"}.icon-link:before{content:"\f0c1"}.icon-cloud:before{content:"\f0c2"}.icon-beaker:before{content:"\f0c3"}.icon-cut:before{content:"\f0c4"}.icon-copy:before{content:"\f0c5"}.icon-paperclip:before,.icon-paper-clip:before{content:"\f0c6"}.icon-save:before{content:"\f0c7"}.icon-sign-blank:before{content:"\f0c8"}.icon-reorder:before{content:"\f0c9"}.icon-list-ul:before{content:"\f0ca"}.icon-list-ol:before{content:"\f0cb"}.icon-strikethrough:before{content:"\f0cc"}.icon-underline:before{content:"\f0cd"}.icon-table:before{content:"\f0ce"}.icon-magic:before{content:"\f0d0"}.icon-truck:before{content:"\f0d1"}.icon-pinterest:before{content:"\f0d2"}.icon-pinterest-sign:before{content:"\f0d3"}.icon-google-plus-sign:before{content:"\f0d4"}.icon-google-plus:before{content:"\f0d5"}.icon-money:before{content:"\f0d6"}.icon-caret-down:before{content:"\f0d7"}.icon-caret-up:before{content:"\f0d8"}.icon-caret-left:before{content:"\f0d9"}.icon-caret-right:before{content:"\f0da"}.icon-columns:before{content:"\f0db"}.icon-sort:before{content:"\f0dc"}.icon-sort-down:before{content:"\f0dd"}.icon-sort-up:before{content:"\f0de"}.icon-envelope:before{content:"\f0e0"}.icon-linkedin:before{content:"\f0e1"}.icon-rotate-left:before,.icon-undo:before{content:"\f0e2"}.icon-legal:before{content:"\f0e3"}.icon-dashboard:before{content:"\f0e4"}.icon-comment-alt:before{content:"\f0e5"}.icon-comments-alt:before{content:"\f0e6"}.icon-bolt:before{content:"\f0e7"}.icon-sitemap:before{content:"\f0e8"}.icon-umbrella:before{content:"\f0e9"}.icon-paste:before{content:"\f0ea"}.icon-lightbulb:before{content:"\f0eb"}.icon-exchange:before{content:"\f0ec"}.icon-cloud-download:before{content:"\f0ed"}.icon-cloud-upload:before{content:"\f0ee"}.icon-user-md:before{content:"\f0f0"}.icon-stethoscope:before{content:"\f0f1"}.icon-suitcase:before{content:"\f0f2"}.icon-bell-alt:before{content:"\f0f3"}.icon-coffee:before{content:"\f0f4"}.icon-food:before{content:"\f0f5"}.icon-file-text-alt:before{content:"\f0f6"}.icon-building:before{content:"\f0f7"}.icon-hospital:before{content:"\f0f8"}.icon-ambulance:before{content:"\f0f9"}.icon-medkit:before{content:"\f0fa"}.icon-fighter-jet:before{content:"\f0fb"}.icon-beer:before{content:"\f0fc"}.icon-h-sign:before{content:"\f0fd"}.icon-plus-sign-alt:before{content:"\f0fe"}.icon-double-angle-left:before{content:"\f100"}.icon-double-angle-right:before{content:"\f101"}.icon-double-angle-up:before{content:"\f102"}.icon-double-angle-down:before{content:"\f103"}.icon-angle-left:before{content:"\f104"}.icon-angle-right:before{content:"\f105"}.icon-angle-up:before{content:"\f106"}.icon-angle-down:before{content:"\f107"}.icon-desktop:before{content:"\f108"}.icon-laptop:before{content:"\f109"}.icon-tablet:before{content:"\f10a"}.icon-mobile-phone:before{content:"\f10b"}.icon-circle-blank:before{content:"\f10c"}.icon-quote-left:before{content:"\f10d"}.icon-quote-right:before{content:"\f10e"}.icon-spinner:before{content:"\f110"}.icon-circle:before{content:"\f111"}.icon-mail-reply:before,.icon-reply:before{content:"\f112"}.icon-github-alt:before{content:"\f113"}.icon-folder-close-alt:before{content:"\f114"}.icon-folder-open-alt:before{content:"\f115"}.icon-expand-alt:before{content:"\f116"}.icon-collapse-alt:before{content:"\f117"}.icon-smile:before{content:"\f118"}.icon-frown:before{content:"\f119"}.icon-meh:before{content:"\f11a"}.icon-gamepad:before{content:"\f11b"}.icon-keyboard:before{content:"\f11c"}.icon-flag-alt:before{content:"\f11d"}.icon-flag-checkered:before{content:"\f11e"}.icon-terminal:before{content:"\f120"}.icon-code:before{content:"\f121"}.icon-reply-all:before{content:"\f122"}.icon-mail-reply-all:before{content:"\f122"}.icon-star-half-full:before,.icon-star-half-empty:before{content:"\f123"}.icon-location-arrow:before{content:"\f124"}.icon-crop:before{content:"\f125"}.icon-code-fork:before{content:"\f126"}.icon-unlink:before{content:"\f127"}.icon-question:before{content:"\f128"}.icon-info:before{content:"\f129"}.icon-exclamation:before{content:"\f12a"}.icon-superscript:before{content:"\f12b"}.icon-subscript:before{content:"\f12c"}.icon-eraser:before{content:"\f12d"}.icon-puzzle-piece:before{content:"\f12e"}.icon-microphone:before{content:"\f130"}.icon-microphone-off:before{content:"\f131"}.icon-shield:before{content:"\f132"}.icon-calendar-empty:before{content:"\f133"}.icon-fire-extinguisher:before{content:"\f134"}.icon-rocket:before{content:"\f135"}.icon-maxcdn:before{content:"\f136"}.icon-chevron-sign-left:before{content:"\f137"}.icon-chevron-sign-right:before{content:"\f138"}.icon-chevron-sign-up:before{content:"\f139"}.icon-chevron-sign-down:before{content:"\f13a"}.icon-html5:before{content:"\f13b"}.icon-css3:before{content:"\f13c"}.icon-anchor:before{content:"\f13d"}.icon-unlock-alt:before{content:"\f13e"}.icon-bullseye:before{content:"\f140"}.icon-ellipsis-horizontal:before{content:"\f141"}.icon-ellipsis-vertical:before{content:"\f142"}.icon-rss-sign:before{content:"\f143"}.icon-play-sign:before{content:"\f144"}.icon-ticket:before{content:"\f145"}.icon-minus-sign-alt:before{content:"\f146"}.icon-check-minus:before{content:"\f147"}.icon-level-up:before{content:"\f148"}.icon-level-down:before{content:"\f149"}.icon-check-sign:before,.wy-inline-validate.wy-inline-validate-success .wy-input-context:before{content:"\f14a"}.icon-edit-sign:before{content:"\f14b"}.icon-external-link-sign:before{content:"\f14c"}.icon-share-sign:before{content:"\f14d"}.icon-compass:before{content:"\f14e"}.icon-collapse:before{content:"\f150"}.icon-collapse-top:before{content:"\f151"}.icon-expand:before{content:"\f152"}.icon-euro:before,.icon-eur:before{content:"\f153"}.icon-gbp:before{content:"\f154"}.icon-dollar:before,.icon-usd:before{content:"\f155"}.icon-rupee:before,.icon-inr:before{content:"\f156"}.icon-yen:before,.icon-jpy:before{content:"\f157"}.icon-renminbi:before,.icon-cny:before{content:"\f158"}.icon-won:before,.icon-krw:before{content:"\f159"}.icon-bitcoin:before,.icon-btc:before{content:"\f15a"}.icon-file:before{content:"\f15b"}.icon-file-text:before{content:"\f15c"}.icon-sort-by-alphabet:before{content:"\f15d"}.icon-sort-by-alphabet-alt:before{content:"\f15e"}.icon-sort-by-attributes:before{content:"\f160"}.icon-sort-by-attributes-alt:before{content:"\f161"}.icon-sort-by-order:before{content:"\f162"}.icon-sort-by-order-alt:before{content:"\f163"}.icon-thumbs-up:before{content:"\f164"}.icon-thumbs-down:before{content:"\f165"}.icon-youtube-sign:before{content:"\f166"}.icon-youtube:before{content:"\f167"}.icon-xing:before{content:"\f168"}.icon-xing-sign:before{content:"\f169"}.icon-youtube-play:before{content:"\f16a"}.icon-dropbox:before{content:"\f16b"}.icon-stackexchange:before{content:"\f16c"}.icon-instagram:before{content:"\f16d"}.icon-flickr:before{content:"\f16e"}.icon-adn:before{content:"\f170"}.icon-bitbucket:before{content:"\f171"}.icon-bitbucket-sign:before{content:"\f172"}.icon-tumblr:before{content:"\f173"}.icon-tumblr-sign:before{content:"\f174"}.icon-long-arrow-down:before{content:"\f175"}.icon-long-arrow-up:before{content:"\f176"}.icon-long-arrow-left:before{content:"\f177"}.icon-long-arrow-right:before{content:"\f178"}.icon-apple:before{content:"\f179"}.icon-windows:before{content:"\f17a"}.icon-android:before{content:"\f17b"}.icon-linux:before{content:"\f17c"}.icon-dribbble:before{content:"\f17d"}.icon-skype:before{content:"\f17e"}.icon-foursquare:before{content:"\f180"}.icon-trello:before{content:"\f181"}.icon-female:before{content:"\f182"}.icon-male:before{content:"\f183"}.icon-gittip:before{content:"\f184"}.icon-sun:before{content:"\f185"}.icon-moon:before{content:"\f186"}.icon-archive:before{content:"\f187"}.icon-bug:before{content:"\f188"}.icon-vk:before{content:"\f189"}.icon-weibo:before{content:"\f18a"}.icon-renren:before{content:"\f18b"}.wy-alert,.rst-content .note,.rst-content .attention,.rst-content .caution,.rst-content .danger,.rst-content .error,.rst-content .hint,.rst-content .important,.rst-content .tip,.rst-content .warning{padding:24px;line-height:24px;margin-bottom:24px;border-left:solid 3px transparent}.wy-alert strong,.rst-content .note strong,.rst-content .attention strong,.rst-content .caution strong,.rst-content .danger strong,.rst-content .error strong,.rst-content .hint strong,.rst-content .important strong,.rst-content .tip strong,.rst-content .warning strong,.wy-alert a,.rst-content .note a,.rst-content .attention a,.rst-content .caution a,.rst-content .danger a,.rst-content .error a,.rst-content .hint a,.rst-content .important a,.rst-content .tip a,.rst-content .warning a{color:#fff}.wy-alert.wy-alert-danger,.rst-content .wy-alert-danger.note,.rst-content .wy-alert-danger.attention,.rst-content .wy-alert-danger.caution,.rst-content .danger,.rst-content .error,.rst-content .wy-alert-danger.hint,.rst-content .wy-alert-danger.important,.rst-content .wy-alert-danger.tip,.rst-content .wy-alert-danger.warning{background:#e74c3c;color:#fff;border-color:#d62c1a}.wy-alert.wy-alert-warning,.rst-content .wy-alert-warning.note,.rst-content .attention,.rst-content .caution,.rst-content .wy-alert-warning.danger,.rst-content .wy-alert-warning.error,.rst-content .wy-alert-warning.hint,.rst-content .wy-alert-warning.important,.rst-content .wy-alert-warning.tip,.rst-content .warning{background:#e67e22;color:#fff;border-color:#bf6516}.wy-alert.wy-alert-info,.rst-content .note,.rst-content .wy-alert-info.attention,.rst-content .wy-alert-info.caution,.rst-content .wy-alert-info.danger,.rst-content .wy-alert-info.error,.rst-content .hint,.rst-content .important,.rst-content .tip,.rst-content .wy-alert-info.warning{background:#2980b9;color:#fff;border-color:#20638f}.wy-alert.wy-alert-success,.rst-content .wy-alert-success.note,.rst-content .wy-alert-success.attention,.rst-content .wy-alert-success.caution,.rst-content .wy-alert-success.danger,.rst-content .wy-alert-success.error,.rst-content .wy-alert-success.hint,.rst-content .wy-alert-success.important,.rst-content .wy-alert-success.tip,.rst-content .wy-alert-success.warning{background:#27ae60;color:#fff;border-color:#1e8449}.wy-alert.wy-alert-neutral,.rst-content .wy-alert-neutral.note,.rst-content .wy-alert-neutral.attention,.rst-content .wy-alert-neutral.caution,.rst-content .wy-alert-neutral.danger,.rst-content .wy-alert-neutral.error,.rst-content .wy-alert-neutral.hint,.rst-content .wy-alert-neutral.important,.rst-content .wy-alert-neutral.tip,.rst-content .wy-alert-neutral.warning{background:#f3f6f6;border-color:#e1e4e5}.wy-alert.wy-alert-neutral strong,.rst-content .wy-alert-neutral.note strong,.rst-content .wy-alert-neutral.attention strong,.rst-content .wy-alert-neutral.caution strong,.rst-content .wy-alert-neutral.danger strong,.rst-content .wy-alert-neutral.error strong,.rst-content .wy-alert-neutral.hint strong,.rst-content .wy-alert-neutral.important strong,.rst-content .wy-alert-neutral.tip strong,.rst-content .wy-alert-neutral.warning strong{color:#404040}.wy-alert.wy-alert-neutral a,.rst-content .wy-alert-neutral.note a,.rst-content .wy-alert-neutral.attention a,.rst-content .wy-alert-neutral.caution a,.rst-content .wy-alert-neutral.danger a,.rst-content .wy-alert-neutral.error a,.rst-content .wy-alert-neutral.hint a,.rst-content .wy-alert-neutral.important a,.rst-content .wy-alert-neutral.tip a,.rst-content .wy-alert-neutral.warning a{color:#2980b9}.wy-tray-container{position:fixed;top:-50px;left:0;width:100%;-webkit-transition:top 0.2s ease-in;-moz-transition:top 0.2s ease-in;transition:top 0.2s ease-in}.wy-tray-container.on{top:0}.wy-tray-container li{display:none;width:100%;background:#343131;padding:12px 24px;color:#fff;margin-bottom:6px;text-align:center;box-shadow:0 5px 5px 0 rgba(0,0,0,0.1),0px -1px 2px -1px rgba(255,255,255,0.5) inset}.wy-tray-container li.wy-tray-item-success{background:#27ae60}.wy-tray-container li.wy-tray-item-info{background:#2980b9}.wy-tray-container li.wy-tray-item-warning{background:#e67e22}.wy-tray-container li.wy-tray-item-danger{background:#e74c3c}.btn{display:inline-block;*display:inline;zoom:1;line-height:normal;white-space:nowrap;vertical-align:baseline;text-align:center;cursor:pointer;-webkit-user-drag:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none;font-size:100%;padding:6px 12px;color:#fff;border:1px solid rgba(0,0,0,0.1);border-bottom:solid 3px rgba(0,0,0,0.1);background-color:#27ae60;text-decoration:none;font-weight:500;box-shadow:0px 1px 2px -1px rgba(255,255,255,0.5) inset;-webkit-transition:all 0.1s linear;-moz-transition:all 0.1s linear;transition:all 0.1s linear;outline-none:false}.btn-hover{background:#2e8ece;color:#fff}.btn:hover{background:#2cc36b;color:#fff}.btn:focus{background:#2cc36b;color:#fff;outline:0}.btn:active{border-top:solid 3px rgba(0,0,0,0.1);border-bottom:solid 1px rgba(0,0,0,0.1);box-shadow:0px 1px 2px -1px rgba(0,0,0,0.5) inset}.btn[disabled]{background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);filter:alpha(opacity=40);opacity:0.4;cursor:not-allowed;box-shadow:none}.btn-disabled{background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);filter:alpha(opacity=40);opacity:0.4;cursor:not-allowed;box-shadow:none}.btn-disabled:hover,.btn-disabled:focus,.btn-disabled:active{background-image:none;filter:progid:DXImageTransform.Microsoft.gradient(enabled = false);filter:alpha(opacity=40);opacity:0.4;cursor:not-allowed;box-shadow:none}.btn::-moz-focus-inner{padding:0;border:0}.btn-small{font-size:80%}.btn-info{background-color:#2980b9 !important}.btn-info:hover{background-color:#2e8ece !important}.btn-neutral{background-color:#f3f6f6 !important;color:#404040 !important}.btn-neutral:hover{background-color:#e5ebeb !important;color:#404040}.btn-danger{background-color:#e74c3c !important}.btn-danger:hover{background-color:#ea6153 !important}.btn-warning{background-color:#e67e22 !important}.btn-warning:hover{background-color:#e98b39 !important}.btn-invert{background-color:#343131}.btn-invert:hover{background-color:#413d3d !important}.btn-link{background-color:transparent !important;color:#2980b9;border-color:transparent}.btn-link:hover{background-color:transparent !important;color:#409ad5;border-color:transparent}.btn-link:active{background-color:transparent !important;border-color:transparent;border-top:solid 1px transparent;border-bottom:solid 3px transparent}.wy-btn-group .btn,.wy-control .btn{vertical-align:middle}.wy-btn-group{margin-bottom:24px;*zoom:1}.wy-btn-group:before,.wy-btn-group:after{display:table;content:""}.wy-btn-group:after{clear:both}.wy-dropdown{position:relative;display:inline-block}.wy-dropdown:hover .wy-dropdown-menu{display:block}.wy-dropdown .caret:after{font-family:fontawesome-webfont;content:"\f0d7";font-size:70%}.wy-dropdown-menu{position:absolute;top:100%;left:0;display:none;float:left;min-width:100%;background:#fcfcfc;z-index:100;border:solid 1px #cfd7dd;box-shadow:0 5px 5px 0 rgba(0,0,0,0.1);padding:12px}.wy-dropdown-menu>dd>a{display:block;clear:both;color:#404040;white-space:nowrap;font-size:90%;padding:0 12px}.wy-dropdown-menu>dd>a:hover{background:#2980b9;color:#fff}.wy-dropdown-menu>dd.divider{border-top:solid 1px #cfd7dd;margin:6px 0}.wy-dropdown-menu>dd.search{padding-bottom:12px}.wy-dropdown-menu>dd.search input[type="search"]{width:100%}.wy-dropdown-menu>dd.call-to-action{background:#e3e3e3;text-transform:uppercase;font-weight:500;font-size:80%}.wy-dropdown-menu>dd.call-to-action:hover{background:#e3e3e3}.wy-dropdown-menu>dd.call-to-action .btn{color:#fff}.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu{background:#fcfcfc;margin-top:2px}.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a{padding:6px 12px}.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover{background:#2980b9;color:#fff}.wy-dropdown.wy-dropdown-left .wy-dropdown-menu{right:0;text-align:right}.wy-dropdown-arrow:before{content:" ";border-bottom:5px solid #f5f5f5;border-left:5px solid transparent;border-right:5px solid transparent;position:absolute;display:block;top:-4px;left:50%;margin-left:-3px}.wy-dropdown-arrow.wy-dropdown-arrow-left:before{left:11px}.wy-form-stacked select{display:block}.wy-form-aligned input,.wy-form-aligned textarea,.wy-form-aligned select,.wy-form-aligned .wy-help-inline,.wy-form-aligned label{display:inline-block;*display:inline;*zoom:1;vertical-align:middle}.wy-form-aligned .wy-control-group>label{display:inline-block;vertical-align:middle;width:10em;margin:0.5em 1em 0 0;float:left}.wy-form-aligned .wy-control{float:left}.wy-form-aligned .wy-control label{display:block}.wy-form-aligned .wy-control select{margin-top:0.5em}fieldset{border:0;margin:0;padding:0}legend{display:block;width:100%;border:0;padding:0;white-space:normal;margin-bottom:24px;font-size:150%;*margin-left:-7px}label{display:block;margin:0 0 0.3125em 0;color:#999;font-size:90%}button,input,select,textarea{font-size:100%;margin:0;vertical-align:baseline;*vertical-align:middle}button,input{line-height:normal}button{-webkit-appearance:button;cursor:pointer;*overflow:visible}button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}button[disabled]{cursor:default}input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer;*overflow:visible}input[type="text"],input[type="password"],input[type="email"],input[type="url"],input[type="date"],input[type="month"],input[type="time"],input[type="datetime"],input[type="datetime-local"],input[type="week"],input[type="number"],input[type="search"],input[type="tel"],input[type="color"]{-webkit-appearance:none;padding:6px;display:inline-block;border:1px solid #ccc;font-size:80%;font-family:"Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;box-shadow:inset 0 1px 3px #ddd;border-radius:0;-webkit-transition:border 0.3s linear;-moz-transition:border 0.3s linear;transition:border 0.3s linear}input[type="datetime-local"]{padding:0.34375em 0.625em}input[disabled]{cursor:default}input[type="checkbox"],input[type="radio"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:0;margin-right:0.3125em;*height:13px;*width:13px}input[type="search"]{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}input[type="search"]::-webkit-search-cancel-button,input[type="search"]::-webkit-search-decoration{-webkit-appearance:none}input[type="text"]:focus,input[type="password"]:focus,input[type="email"]:focus,input[type="url"]:focus,input[type="date"]:focus,input[type="month"]:focus,input[type="time"]:focus,input[type="datetime"]:focus,input[type="datetime-local"]:focus,input[type="week"]:focus,input[type="number"]:focus,input[type="search"]:focus,input[type="tel"]:focus,input[type="color"]:focus{outline:0;outline:thin dotted \9;border-color:#2980b9}input.no-focus:focus{border-color:#ccc !important}input[type="file"]:focus,input[type="radio"]:focus,input[type="checkbox"]:focus{outline:thin dotted #333;outline:1px auto #129fea}input[type="text"][disabled],input[type="password"][disabled],input[type="email"][disabled],input[type="url"][disabled],input[type="date"][disabled],input[type="month"][disabled],input[type="time"][disabled],input[type="datetime"][disabled],input[type="datetime-local"][disabled],input[type="week"][disabled],input[type="number"][disabled],input[type="search"][disabled],input[type="tel"][disabled],input[type="color"][disabled]{cursor:not-allowed;background-color:#f3f6f6;color:#cad2d3}input:focus:invalid,textarea:focus:invalid,select:focus:invalid{color:#e74c3c;border:1px solid #e74c3c}input:focus:invalid:focus,textarea:focus:invalid:focus,select:focus:invalid:focus{border-color:#e9322d}input[type="file"]:focus:invalid:focus,input[type="radio"]:focus:invalid:focus,input[type="checkbox"]:focus:invalid:focus{outline-color:#e9322d}input.wy-input-large{padding:12px;font-size:100%}textarea{overflow:auto;vertical-align:top;width:100%}select,textarea{padding:0.5em 0.625em;display:inline-block;border:1px solid #ccc;font-size:0.8em;box-shadow:inset 0 1px 3px #ddd;-webkit-transition:border 0.3s linear;-moz-transition:border 0.3s linear;transition:border 0.3s linear}select{border:1px solid #ccc;background-color:#fff}select[multiple]{height:auto}select:focus,textarea:focus{outline:0}select[disabled],textarea[disabled],input[readonly],select[readonly],textarea[readonly]{cursor:not-allowed;background-color:#fff;color:#cad2d3;border-color:transparent}.wy-checkbox,.wy-radio{margin:0.5em 0;color:#404040 !important;display:block}.wy-form-message-inline{display:inline-block;*display:inline;*zoom:1;vertical-align:middle}.wy-input-prefix,.wy-input-suffix{white-space:nowrap}.wy-input-prefix .wy-input-context,.wy-input-suffix .wy-input-context{padding:6px;display:inline-block;font-size:80%;background-color:#f3f6f6;border:solid 1px #ccc;color:#999}.wy-input-suffix .wy-input-context{border-left:0}.wy-input-prefix .wy-input-context{border-right:0}.wy-inline-validate{white-space:nowrap}.wy-inline-validate .wy-input-context{padding:0.5em 0.625em;display:inline-block;font-size:80%}.wy-inline-validate.wy-inline-validate-success .wy-input-context{color:#27ae60}.wy-inline-validate.wy-inline-validate-danger .wy-input-context{color:#e74c3c}.wy-inline-validate.wy-inline-validate-warning .wy-input-context{color:#e67e22}.wy-inline-validate.wy-inline-validate-info .wy-input-context{color:#2980b9}.wy-control-group{margin-bottom:24px;*zoom:1}.wy-control-group:before,.wy-control-group:after{display:table;content:""}.wy-control-group:after{clear:both}.wy-control-group.wy-control-group-error .wy-form-message,.wy-control-group.wy-control-group-error label{color:#e74c3c}.wy-control-group.wy-control-group-error input[type="text"],.wy-control-group.wy-control-group-error input[type="password"],.wy-control-group.wy-control-group-error input[type="email"],.wy-control-group.wy-control-group-error input[type="url"],.wy-control-group.wy-control-group-error input[type="date"],.wy-control-group.wy-control-group-error input[type="month"],.wy-control-group.wy-control-group-error input[type="time"],.wy-control-group.wy-control-group-error input[type="datetime"],.wy-control-group.wy-control-group-error input[type="datetime-local"],.wy-control-group.wy-control-group-error input[type="week"],.wy-control-group.wy-control-group-error input[type="number"],.wy-control-group.wy-control-group-error input[type="search"],.wy-control-group.wy-control-group-error input[type="tel"],.wy-control-group.wy-control-group-error input[type="color"]{border:solid 2px #e74c3c}.wy-control-group.wy-control-group-error textarea{border:solid 2px #e74c3c}.wy-control-group.fluid-input input[type="text"],.wy-control-group.fluid-input input[type="password"],.wy-control-group.fluid-input input[type="email"],.wy-control-group.fluid-input input[type="url"],.wy-control-group.fluid-input input[type="date"],.wy-control-group.fluid-input input[type="month"],.wy-control-group.fluid-input input[type="time"],.wy-control-group.fluid-input input[type="datetime"],.wy-control-group.fluid-input input[type="datetime-local"],.wy-control-group.fluid-input input[type="week"],.wy-control-group.fluid-input input[type="number"],.wy-control-group.fluid-input input[type="search"],.wy-control-group.fluid-input input[type="tel"],.wy-control-group.fluid-input input[type="color"]{width:100%}.wy-form-message-inline{display:inline-block;padding-left:0.3em;color:#666;vertical-align:middle;font-size:90%}.wy-form-message{display:block;color:#ccc;font-size:70%;margin-top:0.3125em;font-style:italic}.wy-tag-input-group{padding:4px 4px 0px 4px;display:inline-block;border:1px solid #ccc;font-size:80%;font-family:"Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;box-shadow:inset 0 1px 3px #ddd;-webkit-transition:border 0.3s linear;-moz-transition:border 0.3s linear;transition:border 0.3s linear}.wy-tag-input-group .wy-tag{display:inline-block;background-color:rgba(0,0,0,0.1);padding:0.5em 0.625em;border-radius:2px;position:relative;margin-bottom:4px}.wy-tag-input-group .wy-tag .wy-tag-remove{color:#ccc;margin-left:5px}.wy-tag-input-group .wy-tag .wy-tag-remove:hover{color:#e74c3c}.wy-tag-input-group label{margin-left:5px;display:inline-block;margin-bottom:0}.wy-tag-input-group input{border:none;font-size:100%;margin-bottom:4px;box-shadow:none}.wy-form-upload{border:solid 1px #ccc;border-bottom:solid 3px #ccc;background-color:#fff;padding:24px;display:inline-block;text-align:center;cursor:pointer;color:#404040;-webkit-transition:border-color 0.1s ease-in;-moz-transition:border-color 0.1s ease-in;transition:border-color 0.1s ease-in;*zoom:1}.wy-form-upload:before,.wy-form-upload:after{display:table;content:""}.wy-form-upload:after{clear:both}@media screen and (max-width: 480px){.wy-form-upload{width:100%}}.wy-form-upload .image-drop{display:none}.wy-form-upload .image-desktop{display:none}.wy-form-upload .image-loading{display:none}.wy-form-upload .wy-form-upload-icon{display:block;font-size:32px;color:#b3b3b3}.wy-form-upload .image-drop .wy-form-upload-icon{color:#27ae60}.wy-form-upload p{font-size:90%}.wy-form-upload .wy-form-upload-image{float:left;margin-right:24px}@media screen and (max-width: 480px){.wy-form-upload .wy-form-upload-image{width:100%;margin-bottom:24px}}.wy-form-upload img{max-width:125px;max-height:125px;opacity:0.9;-webkit-transition:opacity 0.1s ease-in;-moz-transition:opacity 0.1s ease-in;transition:opacity 0.1s ease-in}.wy-form-upload .wy-form-upload-content{float:left}@media screen and (max-width: 480px){.wy-form-upload .wy-form-upload-content{width:100%}}.wy-form-upload:hover{border-color:#b3b3b3;color:#404040}.wy-form-upload:hover .image-desktop{display:block}.wy-form-upload:hover .image-drag{display:none}.wy-form-upload:hover img{opacity:1}.wy-form-upload:active{border-top:solid 3px #ccc;border-bottom:solid 1px #ccc}.wy-form-upload.wy-form-upload-big{width:100%;text-align:center;padding:72px}.wy-form-upload.wy-form-upload-big .wy-form-upload-content{float:none}.wy-form-upload.wy-form-upload-file p{margin-bottom:0}.wy-form-upload.wy-form-upload-file .wy-form-upload-icon{display:inline-block;font-size:inherit}.wy-form-upload.wy-form-upload-drop{background-color:#ddf7e8}.wy-form-upload.wy-form-upload-drop .image-drop{display:block}.wy-form-upload.wy-form-upload-drop .image-desktop{display:none}.wy-form-upload.wy-form-upload-drop .image-drag{display:none}.wy-form-upload.wy-form-upload-loading .image-drag{display:none}.wy-form-upload.wy-form-upload-loading .image-desktop{display:none}.wy-form-upload.wy-form-upload-loading .image-loading{display:block}.wy-form-upload.wy-form-upload-loading .wy-input-prefix{display:none}.wy-form-upload.wy-form-upload-loading p{margin-bottom:0}.rotate-90{-webkit-transform:rotate(90deg);-moz-transform:rotate(90deg);-ms-transform:rotate(90deg);-o-transform:rotate(90deg);transform:rotate(90deg)}.rotate-180{-webkit-transform:rotate(180deg);-moz-transform:rotate(180deg);-ms-transform:rotate(180deg);-o-transform:rotate(180deg);transform:rotate(180deg)}.rotate-270{-webkit-transform:rotate(270deg);-moz-transform:rotate(270deg);-ms-transform:rotate(270deg);-o-transform:rotate(270deg);transform:rotate(270deg)}.mirror{-webkit-transform:scaleX(-1);-moz-transform:scaleX(-1);-ms-transform:scaleX(-1);-o-transform:scaleX(-1);transform:scaleX(-1)}.mirror.rotate-90{-webkit-transform:scaleX(-1) rotate(90deg);-moz-transform:scaleX(-1) rotate(90deg);-ms-transform:scaleX(-1) rotate(90deg);-o-transform:scaleX(-1) rotate(90deg);transform:scaleX(-1) rotate(90deg)}.mirror.rotate-180{-webkit-transform:scaleX(-1) rotate(180deg);-moz-transform:scaleX(-1) rotate(180deg);-ms-transform:scaleX(-1) rotate(180deg);-o-transform:scaleX(-1) rotate(180deg);transform:scaleX(-1) rotate(180deg)}.mirror.rotate-270{-webkit-transform:scaleX(-1) rotate(270deg);-moz-transform:scaleX(-1) rotate(270deg);-ms-transform:scaleX(-1) rotate(270deg);-o-transform:scaleX(-1) rotate(270deg);transform:scaleX(-1) rotate(270deg)}.wy-form-gallery-manage{margin-left:-12px;margin-right:-12px}.wy-form-gallery-manage li{float:left;padding:12px;width:20%;cursor:pointer}@media screen and (max-width: 768px){.wy-form-gallery-manage li{width:25%}}@media screen and (max-width: 480px){.wy-form-gallery-manage li{width:50%}}.wy-form-gallery-manage li:active{cursor:move}.wy-form-gallery-manage li>a{padding:12px;background-color:#fff;border:solid 1px #e1e4e5;border-bottom:solid 3px #e1e4e5;display:inline-block;-webkit-transition:all 0.1s ease-in;-moz-transition:all 0.1s ease-in;transition:all 0.1s ease-in}.wy-form-gallery-manage li>a:active{border:solid 1px #ccc;border-top:solid 3px #ccc}.wy-form-gallery-manage img{width:100%;-webkit-transition:all 0.05s ease-in;-moz-transition:all 0.05s ease-in;transition:all 0.05s ease-in}li.wy-form-gallery-edit{position:relative;color:#fff;padding:24px;width:100%;display:block;background-color:#343131;border-radius:4px}li.wy-form-gallery-edit .arrow{position:absolute;display:block;top:-50px;left:50%;margin-left:-25px;z-index:500;height:0;width:0;border-color:transparent;border-style:solid;border-width:25px;border-bottom-color:#343131}@media only screen and (max-width: 480px){.wy-form button[type="submit"]{margin:0.7em 0 0}.wy-form input[type="text"],.wy-form input[type="password"],.wy-form input[type="email"],.wy-form input[type="url"],.wy-form input[type="date"],.wy-form input[type="month"],.wy-form input[type="time"],.wy-form input[type="datetime"],.wy-form input[type="datetime-local"],.wy-form input[type="week"],.wy-form input[type="number"],.wy-form input[type="search"],.wy-form input[type="tel"],.wy-form input[type="color"]{margin-bottom:0.3em;display:block}.wy-form label{margin-bottom:0.3em;display:block}.wy-form input[type="password"],.wy-form input[type="email"],.wy-form input[type="url"],.wy-form input[type="date"],.wy-form input[type="month"],.wy-form input[type="time"],.wy-form input[type="datetime"],.wy-form input[type="datetime-local"],.wy-form input[type="week"],.wy-form input[type="number"],.wy-form input[type="search"],.wy-form input[type="tel"],.wy-form input[type="color"]{margin-bottom:0}.wy-form-aligned .wy-control-group label{margin-bottom:0.3em;text-align:left;display:block;width:100%}.wy-form-aligned .wy-controls{margin:1.5em 0 0 0}.wy-form .wy-help-inline,.wy-form-message-inline,.wy-form-message{display:block;font-size:80%;padding:0.2em 0 0.8em}}@media screen and (max-width: 768px){.tablet-hide{display:none}}@media screen and (max-width: 480px){.mobile-hide{display:none}}.float-left{float:left}.float-right{float:right}.full-width{width:100%}.wy-grid-one-col{*zoom:1;max-width:68em;margin-left:auto;margin-right:auto;max-width:1066px;margin-top:1.618em}.wy-grid-one-col:before,.wy-grid-one-col:after{display:table;content:""}.wy-grid-one-col:after{clear:both}.wy-grid-one-col section{display:block;float:left;margin-right:2.35765%;width:100%;background:#fcfcfc;padding:1.618em;margin-right:0}.wy-grid-one-col section:last-child{margin-right:0}.wy-grid-index-card{*zoom:1;max-width:68em;margin-left:auto;margin-right:auto;max-width:460px;margin-top:1.618em;background:#fcfcfc;padding:1.618em}.wy-grid-index-card:before,.wy-grid-index-card:after{display:table;content:""}.wy-grid-index-card:after{clear:both}.wy-grid-index-card header,.wy-grid-index-card section,.wy-grid-index-card aside{display:block;float:left;margin-right:2.35765%;width:100%}.wy-grid-index-card header:last-child,.wy-grid-index-card section:last-child,.wy-grid-index-card aside:last-child{margin-right:0}.wy-grid-index-card.twocol{max-width:768px}.wy-grid-index-card.twocol section{display:block;float:left;margin-right:2.35765%;width:48.82117%}.wy-grid-index-card.twocol section:last-child{margin-right:0}.wy-grid-index-card.twocol aside{display:block;float:left;margin-right:2.35765%;width:48.82117%}.wy-grid-index-card.twocol aside:last-child{margin-right:0}.wy-grid-search-filter{*zoom:1;max-width:68em;margin-left:auto;margin-right:auto;margin-bottom:24px}.wy-grid-search-filter:before,.wy-grid-search-filter:after{display:table;content:""}.wy-grid-search-filter:after{clear:both}.wy-grid-search-filter .wy-grid-search-filter-input{display:block;float:left;margin-right:2.35765%;width:74.41059%}.wy-grid-search-filter .wy-grid-search-filter-input:last-child{margin-right:0}.wy-grid-search-filter .wy-grid-search-filter-btn{display:block;float:left;margin-right:2.35765%;width:23.23176%}.wy-grid-search-filter .wy-grid-search-filter-btn:last-child{margin-right:0}.wy-table,.rst-content table.docutils,.rst-content table.docutils.field-list{border-collapse:collapse;border-spacing:0;empty-cells:show;margin-bottom:24px}.wy-table caption,.rst-content table.docutils caption,.rst-content table.docutils.field-list caption{color:#000;font:italic 85%/1 arial,sans-serif;padding:1em 0;text-align:center}.wy-table td,.rst-content table.docutils td,.rst-content table.docutils.field-list td,.wy-table th,.rst-content table.docutils th,.rst-content table.docutils.field-list th{font-size:90%;margin:0;overflow:visible;padding:8px 16px}.wy-table td:first-child,.rst-content table.docutils td:first-child,.wy-table th:first-child,.rst-content table.docutils th:first-child{border-left-width:0}.wy-table thead,.rst-content table.docutils thead,.rst-content table.docutils.field-list thead{color:#000;text-align:left;vertical-align:bottom;white-space:nowrap}.wy-table thead th,.rst-content table.docutils thead th,.rst-content table.docutils.field-list thead th{font-weight:bold;border-bottom:solid 2px #e1e4e5}.wy-table td,.rst-content table.docutils td,.rst-content table.docutils.field-list td{background-color:transparent;vertical-align:middle}.wy-table td p,.rst-content table.docutils td p,.rst-content table.docutils.field-list td p{line-height:18px;margin-bottom:0}.wy-table .wy-table-cell-min,.rst-content table.docutils .wy-table-cell-min{width:1%;padding-right:0}.wy-table .wy-table-cell-min input[type=checkbox],.rst-content table.docutils .wy-table-cell-min input[type=checkbox],.wy-table .wy-table-cell-min input[type=checkbox],.rst-content table.docutils .wy-table-cell-min input[type=checkbox]{margin:0}.wy-table-secondary{color:gray;font-size:90%}.wy-table-tertiary{color:gray;font-size:80%}.wy-table-odd td,.wy-table-striped tr:nth-child(2n-1) td,.rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td{background-color:#f3f6f6}.wy-table-backed{background-color:#f3f6f6}.wy-table-bordered-all,.rst-content table.docutils{border:1px solid #e1e4e5}.wy-table-bordered-all td,.rst-content table.docutils td{border-bottom:1px solid #e1e4e5;border-left:1px solid #e1e4e5}.wy-table-bordered-all tbody>tr:last-child td,.rst-content table.docutils tbody>tr:last-child td{border-bottom-width:0}.wy-table-bordered{border:1px solid #e1e4e5}.wy-table-bordered-rows td{border-bottom:1px solid #e1e4e5}.wy-table-bordered-rows tbody>tr:last-child td{border-bottom-width:0}.wy-table-horizontal tbody>tr:last-child td{border-bottom-width:0}.wy-table-horizontal td,.wy-table-horizontal th{border-width:0 0 1px 0;border-bottom:1px solid #e1e4e5}.wy-table-horizontal tbody>tr:last-child td{border-bottom-width:0}.wy-table-responsive{margin-bottom:24px;max-width:100%;overflow:auto}.wy-table-responsive table{margin-bottom:0 !important}.wy-table-responsive table td,.wy-table-responsive table th{white-space:nowrap}html{height:100%;overflow-x:hidden}body{font-family:"Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;font-weight:normal;color:#404040;min-height:100%;overflow-x:hidden;background:#edf0f2}a{color:#2980b9;text-decoration:none}a:hover{color:#3091d1}.link-danger{color:#e74c3c}.link-danger:hover{color:#d62c1a}.text-left{text-align:left}.text-center{text-align:center}.text-right{text-align:right}h1,h2,h3,h4,h5,h6,legend{margin-top:0;font-weight:700;font-family:"Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif}p{line-height:24px;margin:0;font-size:16px;margin-bottom:24px}h1{font-size:175%}h2{font-size:150%}h3{font-size:125%}h4{font-size:115%}h5{font-size:110%}h6{font-size:100%}small{font-size:80%}code,.rst-content dl dt,.rst-content dl dl dt,.rst-content tt.literal{white-space:nowrap;max-width:100%;background:#fff;border:solid 1px #e1e4e5;font-size:80%;padding:0 5px;font-family:"Incosolata","Consolata","Monaco",monospace;color:#e74c3c;overflow-x:auto}code.code-large,.rst-content dl dt.code-large,.rst-content tt.code-large.literal{font-size:90%}.full-width{width:100%}.wy-plain-list-disc,.rst-content .section ul,.rst-content ul.simple,.rst-content ul.stimple ul,.rst-content .toctree-wrapper ul{list-style:disc;line-height:24px;margin-bottom:24px}.wy-plain-list-disc li,.rst-content .section ul li,.rst-content ul.simple li,.rst-content ul.stimple ul li,.rst-content .toctree-wrapper ul li{list-style:disc;margin-left:24px}.wy-plain-list-disc li ul,.rst-content .section ul li ul,.rst-content ul.simple li ul,.rst-content ul.stimple ul li ul,.rst-content .toctree-wrapper ul li ul{margin-bottom:0}.wy-plain-list-disc li li,.rst-content .section ul li li,.rst-content ul.simple li li,.rst-content ul.stimple ul li li,.rst-content .toctree-wrapper ul li li{list-style:circle}.wy-plain-list-disc li li li,.rst-content .section ul li li li,.rst-content ul.simple li li li,.rst-content ul.stimple ul li li li,.rst-content .toctree-wrapper ul li li li{list-style:square}.wy-plain-list-decimal,.rst-content .section ol,.rst-content ol.simple,.rst-content ol.arabic{list-style:decimal;line-height:24px;margin-bottom:24px}.wy-plain-list-decimal li,.rst-content .section ol li,.rst-content ol.simple li,.rst-content ol.arabic li{list-style:decimal;margin-left:24px}.wy-type-large{font-size:120%}.wy-type-normal{font-size:100%}.wy-type-small{font-size:100%}.wy-type-strike{text-decoration:line-through}.wy-text-warning{color:#e67e22 !important}a.wy-text-warning:hover{color:#eb9950 !important}.wy-text-info{color:#2980b9 !important}a.wy-text-info:hover{color:#409ad5 !important}.wy-text-success{color:#27ae60 !important}a.wy-text-success:hover{color:#36d278 !important}.wy-text-danger{color:#e74c3c !important}a.wy-text-danger:hover{color:#ed7669 !important}.wy-text-neutral{color:#404040 !important}a.wy-text-neutral:hover{color:#595959 !important}.codeblock-example{border:1px solid #e1e4e5;border-bottom:none;padding:24px;padding-top:48px;font-weight:500;background:#fff;position:relative}.codeblock-example:after{content:"Example";position:absolute;top:0px;left:0px;background:#9b59b6;color:#fff;padding:6px 12px}.codeblock-example.prettyprint-example-only{border:1px solid #e1e4e5;margin-bottom:24px}.codeblock,div[class^='highlight']{border:1px solid #e1e4e5;padding:0px;width:100%;overflow-x:auto;background:#fff;margin:1px 0 24px 0}.codeblock div[class^='highlight'],div[class^='highlight'] div[class^='highlight']{border:none;background:none;margin:0}.linenodiv pre{border-right:solid 1px #e6e9ea;margin:0;padding:12px 12px;font-family:Menlo,"Bitstream Vera Sans Mono","DejaVu Sans Mono",Monaco,Consolas,"source-code-pro-1","source-code-pro-2",monospace;font-size:12px;line-height:1.5;color:#d9d9d9}div[class^='highlight'] pre{white-space:pre;margin:0;padding:12px 12px;font-family:Menlo,"Bitstream Vera Sans Mono","DejaVu Sans Mono",Monaco,Consolas,"source-code-pro-1","source-code-pro-2",monospace;font-size:12px;line-height:1.5;display:block;overflow:auto;color:#404040}pre.literal-block{@extends .codeblock;;background:#343131;color:#fff;padding:42px 12px 12px 12px;font-family:Menlo,"Bitstream Vera Sans Mono","DejaVu Sans Mono",Monaco,Consolas,"source-code-pro-1","source-code-pro-2",monospace;font-size:12px;line-height:1.5;position:relative}pre.literal-block:after{position:absolute;content:"  Terminal";background:#f3f6f6;color:#404040;top:0;left:0;width:100%;padding:6px 0}@media print{.codeblock,div[class^='highlight'],div[class^='highlight'] pre{white-space:pre-wrap}}.hll{background-color:#f8f8f8;border:1px solid #ccc;padding:1.5px 5px}.c{color:#998;font-style:italic}.err{color:#a61717;background-color:#e3d2d2}.k{font-weight:bold}.o{font-weight:bold}.cm{color:#998;font-style:italic}.cp{color:#999;font-weight:bold}.c1{color:#998;font-style:italic}.cs{color:#999;font-weight:bold;font-style:italic}.gd{color:#000;background-color:#fdd}.gd .x{color:#000;background-color:#faa}.ge{font-style:italic}.gr{color:#a00}.gh{color:#999}.gi{color:#000;background-color:#dfd}.gi .x{color:#000;background-color:#afa}.go{color:#888}.gp{color:#555}.gs{font-weight:bold}.gu{color:purple;font-weight:bold}.gt{color:#a00}.kc{font-weight:bold}.kd{font-weight:bold}.kn{font-weight:bold}.kp{font-weight:bold}.kr{font-weight:bold}.kt{color:#458;font-weight:bold}.m{color:#099}.s{color:#d14}.n{color:#333}.na{color:teal}.nb{color:#0086b3}.nc{color:#458;font-weight:bold}.no{color:teal}.ni{color:purple}.ne{color:#900;font-weight:bold}.nf{color:#900;font-weight:bold}.nn{color:#555}.nt{color:navy}.nv{color:teal}.ow{font-weight:bold}.w{color:#bbb}.mf{color:#099}.mh{color:#099}.mi{color:#099}.mo{color:#099}.sb{color:#d14}.sc{color:#d14}.sd{color:#d14}.s2{color:#d14}.se{color:#d14}.sh{color:#d14}.si{color:#d14}.sx{color:#d14}.sr{color:#009926}.s1{color:#d14}.ss{color:#990073}.bp{color:#999}.vc{color:teal}.vg{color:teal}.vi{color:teal}.il{color:#099}.gc{color:#999;background-color:#eaf2f5}.wy-breadcrumbs li{display:inline-block}.wy-breadcrumbs li.wy-breadcrumbs-aside{float:right}.wy-breadcrumbs li a{display:inline-block;padding:5px}.wy-breadcrumbs li a:first-child{padding-left:0}.wy-breadcrumbs-extra{margin-bottom:0;color:#b3b3b3;font-size:80%;display:inline-block}@media screen and (max-width: 480px){.wy-breadcrumbs-extra{display:none}.wy-breadcrumbs li.wy-breadcrumbs-aside{display:none}}@media print{.wy-breadcrumbs li.wy-breadcrumbs-aside{display:none}}.wy-affix{position:fixed;top:1.618em}.wy-menu a:hover{text-decoration:none}.wy-menu-horiz{*zoom:1}.wy-menu-horiz:before,.wy-menu-horiz:after{display:table;content:""}.wy-menu-horiz:after{clear:both}.wy-menu-horiz ul,.wy-menu-horiz li{display:inline-block}.wy-menu-horiz li:hover{background:rgba(255,255,255,0.1)}.wy-menu-horiz li.divide-left{border-left:solid 1px #404040}.wy-menu-horiz li.divide-right{border-right:solid 1px #404040}.wy-menu-horiz a{height:32px;display:inline-block;line-height:32px;padding:0 16px}.wy-menu-vertical header{height:32px;display:inline-block;line-height:32px;padding:0 1.618em;display:block;font-weight:bold;text-transform:uppercase;font-size:80%;color:#2980b9;white-space:nowrap}.wy-menu-vertical ul{margin-bottom:0}.wy-menu-vertical li.divide-top{border-top:solid 1px #404040}.wy-menu-vertical li.divide-bottom{border-bottom:solid 1px #404040}.wy-menu-vertical li.current{background:#e3e3e3}.wy-menu-vertical li.current a{color:gray;border-right:solid 1px #c9c9c9;padding:0.4045em 2.427em}.wy-menu-vertical li.current a:hover{background:#d6d6d6}.wy-menu-vertical li.current a .current{background:#c9c9c9}.wy-menu-vertical li.on a,.wy-menu-vertical li.current>a{color:#404040;padding:0.4045em 1.618em;font-weight:bold;position:relative;background:#fcfcfc;border:none;border-bottom:solid 1px #c9c9c9;padding-left:1.618em -4px}.wy-menu-vertical li.on a:hover,.wy-menu-vertical li.current>a:hover{background:#fcfcfc}.wy-menu-vertical li.current ul{display:block}.wy-menu-vertical li ul{margin-bottom:0;display:none}.wy-menu-vertical li ul li a{margin-bottom:0;color:#b3b3b3;font-weight:normal}.wy-menu-vertical a{display:inline-block;line-height:18px;padding:0.4045em 1.618em;display:block;position:relative;font-size:90%;color:#b3b3b3}.wy-menu-vertical a:hover{background-color:#4e4a4a;cursor:pointer}.wy-menu-vertical a:active{background-color:#2980b9;cursor:pointer;color:#fff}.wy-side-nav-search{z-index:200;background-color:#2980b9;text-align:center;padding:0.809em;display:block;color:#fcfcfc;margin-bottom:0.809em}.wy-side-nav-search input[type=text]{width:100%;border-radius:50px;padding:6px 12px;border-color:#2472a4}.wy-side-nav-search img{display:block;margin:auto auto 0.809em auto;height:45px;width:45px;background-color:#2980b9;padding:5px;border-radius:100%}.wy-side-nav-search>a,.wy-side-nav-search .wy-dropdown>a{color:#fcfcfc;font-size:100%;font-weight:bold;display:inline-block;padding:4px 6px;margin-bottom:0.809em}.wy-side-nav-search>a:hover,.wy-side-nav-search .wy-dropdown>a:hover{background:rgba(255,255,255,0.1)}.wy-nav .wy-menu-vertical header{color:#2980b9}.wy-nav .wy-menu-vertical a{color:#b3b3b3}.wy-nav .wy-menu-vertical a:hover{background-color:#2980b9;color:#fff}[data-menu-wrap]{-webkit-transition:all 0.2s ease-in;-moz-transition:all 0.2s ease-in;transition:all 0.2s ease-in;position:absolute;opacity:1;width:100%;opacity:0}[data-menu-wrap].move-center{left:0;right:auto;opacity:1}[data-menu-wrap].move-left{right:auto;left:-100%;opacity:0}[data-menu-wrap].move-right{right:-100%;left:auto;opacity:0}.wy-body-for-nav{background:left repeat-y #fcfcfc;background-image:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDoxOERBMTRGRDBFMUUxMUUzODUwMkJCOThDMEVFNURFMCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDoxOERBMTRGRTBFMUUxMUUzODUwMkJCOThDMEVFNURFMCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjE4REExNEZCMEUxRTExRTM4NTAyQkI5OEMwRUU1REUwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjE4REExNEZDMEUxRTExRTM4NTAyQkI5OEMwRUU1REUwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+EwrlwAAAAA5JREFUeNpiMDU0BAgwAAE2AJgB9BnaAAAAAElFTkSuQmCC);background-size:300px 1px}.wy-grid-for-nav{position:absolute;width:100%;height:100%}.wy-nav-side{position:absolute;top:0;left:0;width:300px;overflow:hidden;min-height:100%;background:#343131;z-index:200}.wy-nav-top{display:none;background:#2980b9;color:#fff;padding:0.4045em 0.809em;position:relative;line-height:50px;text-align:center;font-size:100%;*zoom:1}.wy-nav-top:before,.wy-nav-top:after{display:table;content:""}.wy-nav-top:after{clear:both}.wy-nav-top a{color:#fff;font-weight:bold}.wy-nav-top img{margin-right:12px;height:45px;width:45px;background-color:#2980b9;padding:5px;border-radius:100%}.wy-nav-top i{font-size:30px;float:left;cursor:pointer}.wy-nav-content-wrap{margin-left:300px;background:#fcfcfc;min-height:100%}.wy-nav-content{padding:1.618em 3.236em;height:100%;max-width:800px;margin:auto}.wy-body-mask{position:fixed;width:100%;height:100%;background:rgba(0,0,0,0.2);display:none;z-index:499}.wy-body-mask.on{display:block}footer{color:#999}footer p{margin-bottom:12px}.rst-footer-buttons{*zoom:1}.rst-footer-buttons:before,.rst-footer-buttons:after{display:table;content:""}.rst-footer-buttons:after{clear:both}@media screen and (max-width: 768px){.wy-body-for-nav{background:#fcfcfc}.wy-nav-top{display:block}.wy-nav-side{left:-300px}.wy-nav-side.shift{width:85%;left:0}.wy-nav-content-wrap{margin-left:0}.wy-nav-content-wrap .wy-nav-content{padding:1.618em}.wy-nav-content-wrap.shift{position:fixed;min-width:100%;left:85%;top:0;height:100%;overflow:hidden}}@media screen and (min-width: 1400px){.wy-nav-content-wrap{background:rgba(0,0,0,0.05)}.wy-nav-content{margin:0;background:#fcfcfc}}@media print{.wy-nav-side{display:none}.wy-nav-content-wrap{margin-left:0}}.rst-versions{position:fixed;bottom:0;left:0;width:300px;color:#fcfcfc;background:#1f1d1d;border-top:solid 10px #343131;font-family:"Lato","proxima-nova","Helvetica Neue",Arial,sans-serif;z-index:400}.rst-versions a{color:#2980b9;text-decoration:none}.rst-versions .rst-badge-small{display:none}.rst-versions .rst-current-version{padding:12px;background-color:#272525;display:block;text-align:right;font-size:90%;cursor:pointer;color:#27ae60;*zoom:1}.rst-versions .rst-current-version:before,.rst-versions .rst-current-version:after{display:table;content:""}.rst-versions .rst-current-version:after{clear:both}.rst-versions .rst-current-version .icon,.rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-success .wy-input-context,.wy-inline-validate.wy-inline-validate-success .rst-versions .rst-current-version .wy-input-context,.rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-danger .wy-input-context,.wy-inline-validate.wy-inline-validate-danger .rst-versions .rst-current-version .wy-input-context,.rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-warning .wy-input-context,.wy-inline-validate.wy-inline-validate-warning .rst-versions .rst-current-version .wy-input-context,.rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-info .wy-input-context,.wy-inline-validate.wy-inline-validate-info .rst-versions .rst-current-version .wy-input-context,.rst-versions .rst-current-version .wy-tag-input-group .wy-tag .wy-tag-remove,.wy-tag-input-group .wy-tag .rst-versions .rst-current-version .wy-tag-remove,.rst-versions .rst-current-version .rst-content .admonition-title,.rst-content .rst-versions .rst-current-version .admonition-title,.rst-versions .rst-current-version .rst-content h1 .headerlink,.rst-content h1 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h2 .headerlink,.rst-content h2 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h3 .headerlink,.rst-content h3 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h4 .headerlink,.rst-content h4 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h5 .headerlink,.rst-content h5 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content h6 .headerlink,.rst-content h6 .rst-versions .rst-current-version .headerlink,.rst-versions .rst-current-version .rst-content dl dt .headerlink,.rst-content dl dt .rst-versions .rst-current-version .headerlink{color:#fcfcfc}.rst-versions .rst-current-version .icon-book{float:left}.rst-versions .rst-current-version.rst-out-of-date{background-color:#e74c3c;color:#fff}.rst-versions.shift-up .rst-other-versions{display:block}.rst-versions .rst-other-versions{font-size:90%;padding:12px;color:gray;display:none}.rst-versions .rst-other-versions hr{display:block;height:1px;border:0;margin:20px 0;padding:0;border-top:solid 1px #413d3d}.rst-versions .rst-other-versions dd{display:inline-block;margin:0}.rst-versions .rst-other-versions dd a{display:inline-block;padding:6px;color:#fcfcfc}.rst-versions.rst-badge{width:auto;bottom:20px;right:20px;left:auto;border:none;max-width:300px}.rst-versions.rst-badge .icon-book{float:none}.rst-versions.rst-badge.shift-up .rst-current-version{text-align:right}.rst-versions.rst-badge.shift-up .rst-current-version .icon-book{float:left}.rst-versions.rst-badge .rst-current-version{width:auto;height:30px;line-height:30px;padding:0 6px;display:block;text-align:center}@media screen and (max-width: 768px){.rst-versions{width:85%;display:none}.rst-versions.shift{display:block}img{width:100%;height:auto}}.rst-content img{max-width:100%;height:auto !important}.rst-content .section>img{margin-bottom:24px}.rst-content .note p.last,.rst-content .note p.first,.rst-content .attention p.last,.rst-content .attention p.first,.rst-content .caution p.last,.rst-content .caution p.first,.rst-content .danger p.last,.rst-content .danger p.first,.rst-content .error p.last,.rst-content .error p.first,.rst-content .hint p.last,.rst-content .hint p.first,.rst-content .important p.last,.rst-content .important p.first,.rst-content .tip p.last,.rst-content .tip p.first,.rst-content .warning p.last,.rst-content .warning p.first{margin-bottom:0}.rst-content .admonition-title{font-weight:bold}.rst-content .admonition-title:before{margin-right:4px}.rst-content .topic-title{font-weight:bold;margin-bottom:12px}.rst-content .toc-backref{color:#404040}.rst-content .align-right{float:right;margin:0px 0px 24px 24px}.rst-content .align-left{float:left;margin:0px 24px 24px 0px}.rst-content h1 .headerlink,.rst-content h2 .headerlink,.rst-content h3 .headerlink,.rst-content h4 .headerlink,.rst-content h5 .headerlink,.rst-content h6 .headerlink,.rst-content dl dt .headerlink{display:none;visibility:hidden;font-size:14px}.rst-content h1 .headerlink:after,.rst-content h2 .headerlink:after,.rst-content h3 .headerlink:after,.rst-content h4 .headerlink:after,.rst-content h5 .headerlink:after,.rst-content h6 .headerlink:after,.rst-content dl dt .headerlink:after{visibility:visible;content:"\f0c1";font-family:fontawesome-webfont;display:inline-block}.rst-content h1:hover .headerlink,.rst-content h2:hover .headerlink,.rst-content h3:hover .headerlink,.rst-content h4:hover .headerlink,.rst-content h5:hover .headerlink,.rst-content h6:hover .headerlink,.rst-content dl dt:hover .headerlink{display:inline-block}.rst-content .sidebar{float:right;width:40%;display:block;margin:0 0 24px 24px;padding:24px;background:#f3f6f6;border:solid 1px #e1e4e5}.rst-content .sidebar p,.rst-content .sidebar ul,.rst-content .sidebar dl{font-size:90%}.rst-content .sidebar .last{margin-bottom:0}.rst-content .sidebar .sidebar-title{display:block;font-family:"Roboto Slab","ff-tisa-web-pro","Georgia",Arial,sans-serif;font-weight:bold;background:#e1e4e5;padding:6px 12px;margin:-24px;margin-bottom:24px;font-size:100%}.rst-content table.docutils.citation,.rst-content table.docutils.footnote{background:none;border:none;color:#999}.rst-content table.docutils.citation td,.rst-content table.docutils.citation tr,.rst-content table.docutils.footnote td,.rst-content table.docutils.footnote tr{border:none;background-color:transparent !important;white-space:normal}.rst-content table.docutils.citation td.label,.rst-content table.docutils.footnote td.label{padding-left:0;padding-right:0;vertical-align:top}.rst-content .footnote-reference,.rst-content .citation-reference{vertical-align:super;font-size:90%}.rst-content table.docutils.field-list{border:none}.rst-content table.docutils.field-list td{border:none}.rst-content table.docutils.field-list .field-name{padding-right:5px;text-align:left}.rst-content table.docutils.field-list .field-body{text-align:left;padding-left:0}.rst-content dl dt{display:inline-block;margin:6px 0;font-size:80%;line-height:normal;background:#ccc;color:#333;border:none;border-left:solid 3px #999;padding:6px}.rst-content dl dt .headerlink{color:#404040;font-size:100% !important}.rst-content dl dt .descname,.rst-content dl dt .descclassname,.rst-content dl dt big,.rst-content dl dt em{font-size:100% !important;line-height:normal}.rst-content dl dt:first-child{margin-top:0}.rst-content dl dd{margin-left:24px}.rst-content dl dl dt{display:inline-block;margin-bottom:6px;font-size:80%;line-height:normal}.rst-content dl dl dt .headerlink{color:#404040;font-size:100% !important}.rst-content tt{font-family:"Incosolata","Consolata","Monaco",monospace}.rst-content blockquote{margin-left:24px;line-height:24px;margin-bottom:24px}.rst-content #search-results .search li{margin-bottom:24px;border-bottom:solid 1px #e1e4e5;padding-bottom:24px}.rst-content #search-results .search li:first-child{border-top:solid 1px #e1e4e5;padding-top:24px}.rst-content #search-results .search li a{font-size:120%;margin-bottom:12px;display:inline-block}.rst-content #search-results .context{color:gray;font-size:90%}@media screen and (max-width: 480px){.rst-content .sidebar{width:100%}}
+/* line 2, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_grid.scss */
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+article, aside, details, figcaption, figure, footer, header, hgroup, nav, section {
+  display: block;
+}
+
+/* line 4, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+audio, canvas, video {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+}
+
+/* line 9, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+audio:not([controls]) {
+  display: none;
+}
+
+/* line 12, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+[hidden] {
+  display: none;
+}
+
+/* line 15, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* line 18, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+}
+
+/* line 23, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+body {
+  margin: 0;
+}
+
+/* line 26, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+a:hover, a:active {
+  outline: 0;
+}
+
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+abbr[title] {
+  border-bottom: 1px dotted;
+}
+
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+b, strong {
+  font-weight: bold;
+}
+
+/* line 35, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+blockquote {
+  margin: 0;
+}
+
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+dfn {
+  font-style: italic;
+}
+
+/* line 41, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  border-top: 1px solid #cccccc;
+  margin: 20px 0;
+  padding: 0;
+}
+
+/* line 49, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+ins {
+  background: #ffff99;
+  color: black;
+  text-decoration: none;
+}
+
+/* line 54, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+mark {
+  background: yellow;
+  color: black;
+  font-style: italic;
+  font-weight: bold;
+}
+
+/* line 60, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+pre, code, kbd, samp {
+  font-family: monospace, serif;
+  _font-family: "courier new", monospace;
+  font-size: 1em;
+}
+
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+pre {
+  white-space: pre;
+}
+
+/* line 68, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+q {
+  quotes: none;
+}
+
+/* line 71, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+q:before, q:after {
+  content: "";
+  content: none;
+}
+
+/* line 75, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+small {
+  font-size: 85%;
+}
+
+/* line 78, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+sub, sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+/* line 84, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+sup {
+  top: -0.5em;
+}
+
+/* line 87, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+sub {
+  bottom: -0.25em;
+}
+
+/* line 90, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+ul, ol, dl {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  list-style-image: none;
+}
+
+/* line 96, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+li {
+  list-style: none;
+}
+
+/* line 99, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+dd {
+  margin: 0;
+}
+
+/* line 102, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+img {
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+  vertical-align: middle;
+  max-width: 100%;
+}
+
+/* line 108, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+svg:not(:root) {
+  overflow: hidden;
+}
+
+/* line 111, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+figure {
+  margin: 0;
+}
+
+/* line 114, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+form {
+  margin: 0;
+}
+
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* line 122, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+label {
+  cursor: pointer;
+}
+
+/* line 125, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+legend {
+  border: 0;
+  *margin-left: -7px;
+  padding: 0;
+  white-space: normal;
+}
+
+/* line 131, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+button, input, select, textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+
+/* line 137, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+button, input {
+  line-height: normal;
+}
+
+/* line 140, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+button, input[type="button"], input[type="reset"], input[type="submit"] {
+  cursor: pointer;
+  -webkit-appearance: button;
+  *overflow: visible;
+}
+
+/* line 145, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+button[disabled], input[disabled] {
+  cursor: default;
+}
+
+/* line 148, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+input[type="checkbox"], input[type="radio"] {
+  box-sizing: border-box;
+  padding: 0;
+  *width: 13px;
+  *height: 13px;
+}
+
+/* line 154, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+input[type="search"] {
+  -webkit-appearance: textfield;
+  -moz-box-sizing: content-box;
+  -webkit-box-sizing: content-box;
+  box-sizing: content-box;
+}
+
+/* line 160, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+/* line 163, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+button::-moz-focus-inner, input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/* line 167, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+textarea {
+  overflow: auto;
+  vertical-align: top;
+  resize: vertical;
+}
+
+/* line 172, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+table {
+  border-collapse: collapse;
+  border-spacing: 0;
+}
+
+/* line 176, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+td {
+  vertical-align: top;
+}
+
+/* line 179, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.chromeframe {
+  margin: 0.2em 0;
+  background: #cccccc;
+  color: black;
+  padding: 0.2em 0;
+}
+
+/* line 185, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.ir {
+  display: block;
+  border: 0;
+  text-indent: -999em;
+  overflow: hidden;
+  background-color: transparent;
+  background-repeat: no-repeat;
+  text-align: left;
+  direction: ltr;
+  *line-height: 0;
+}
+
+/* line 196, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.ir br {
+  display: none;
+}
+
+/* line 199, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.hidden {
+  display: none !important;
+  visibility: hidden;
+}
+
+/* line 203, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.visuallyhidden {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}
+
+/* line 213, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.visuallyhidden.focusable:active, .visuallyhidden.focusable:focus {
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto;
+}
+
+/* line 221, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.invisible {
+  visibility: hidden;
+}
+
+/* line 224, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+.relative {
+  position: relative;
+}
+
+/* line 227, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+big, small {
+  font-size: 100%;
+}
+
+@media print {
+  /* line 231, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  html, body, section {
+    background: none !important;
+  }
+
+  /* line 233, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  * {
+    box-shadow: none !important;
+    text-shadow: none !important;
+    filter: none !important;
+    -ms-filter: none !important;
+  }
+
+  /* line 238, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  a, a:visited {
+    text-decoration: underline;
+  }
+
+  /* line 240, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  .ir a:after, a[href^="javascript:"]:after, a[href^="#"]:after {
+    content: "";
+  }
+
+  /* line 242, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  pre, blockquote {
+    page-break-inside: avoid;
+  }
+
+  /* line 244, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  thead {
+    display: table-header-group;
+  }
+
+  /* line 246, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  tr, img {
+    page-break-inside: avoid;
+  }
+
+  /* line 248, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  img {
+    max-width: 100% !important;
+  }
+
+  @page {
+    margin: 0.5cm;
+}
+
+  /* line 253, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  p, h2, h3 {
+    orphans: 3;
+    widows: 3;
+  }
+
+  /* line 256, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_reset.sass */
+  h2, h3 {
+    page-break-after: avoid;
+  }
+}
+/* line 70, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.font-smooth, .icon:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .wy-tag-input-group .wy-tag .wy-tag-remove:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before, .wy-alert, .rst-content .note, .rst-content .attention, .rst-content .caution, .rst-content .danger, .rst-content .error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .warning, .btn, input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"], select, textarea, .wy-tag-input-group, .wy-menu-vertical li.on a, .wy-menu-vertical li.current > a, .wy-side-nav-search > a, .wy-side-nav-search .wy-dropdown > a, .wy-nav-top a {
+  -webkit-font-smoothing: antialiased;
+}
+
+/* line 124, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix {
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix:before, .clearfix:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.clearfix:after {
+  clear: both;
+}
+
+@font-face {
+  font-family: fontawesome-webfont;
+  font-weight: normal;
+  font-style: normal;
+  src: url("../font/fontawesome_webfont.eot");
+  src: url("../font/fontawesome_webfont.eot?#iefix") format("embedded-opentype"), url("../font/fontawesome_webfont.woff") format("woff"), url("../font/fontawesome_webfont.ttf") format("truetype"), url("../font/fontawesome_webfont.svg#fontawesome-webfont") format("svg");
+}
+
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .wy-tag-input-group .wy-tag .wy-tag-remove:before, .rst-content .admonition-title:before, .rst-content h1 .headerlink:before, .rst-content h2 .headerlink:before, .rst-content h3 .headerlink:before, .rst-content h4 .headerlink:before, .rst-content h5 .headerlink:before, .rst-content h6 .headerlink:before, .rst-content dl dt .headerlink:before {
+  display: inline-block;
+  font-family: fontawesome-webfont;
+  font-style: normal;
+  font-weight: normal;
+  line-height: 1;
+  text-decoration: inherit;
+}
+
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+a .icon, a .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success a .wy-input-context, a .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger a .wy-input-context, a .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning a .wy-input-context, a .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info a .wy-input-context, a .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag a .wy-tag-remove, a .rst-content .admonition-title, .rst-content a .admonition-title, a .rst-content h1 .headerlink, .rst-content h1 a .headerlink, a .rst-content h2 .headerlink, .rst-content h2 a .headerlink, a .rst-content h3 .headerlink, .rst-content h3 a .headerlink, a .rst-content h4 .headerlink, .rst-content h4 a .headerlink, a .rst-content h5 .headerlink, .rst-content h5 a .headerlink, a .rst-content h6 .headerlink, .rst-content h6 a .headerlink, a .rst-content dl dt .headerlink, .rst-content dl dt a .headerlink {
+  display: inline-block;
+  text-decoration: inherit;
+}
+
+/* makes the font 33% larger relative to the icon container */
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-large:before {
+  vertical-align: -10%;
+  font-size: 1.33333em;
+}
+
+/* line 24, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn .icon, .btn .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success .btn .wy-input-context, .btn .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger .btn .wy-input-context, .btn .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning .btn .wy-input-context, .btn .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info .btn .wy-input-context, .btn .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag .btn .wy-tag-remove, .btn .rst-content .admonition-title, .rst-content .btn .admonition-title, .btn .rst-content h1 .headerlink, .rst-content h1 .btn .headerlink, .btn .rst-content h2 .headerlink, .rst-content h2 .btn .headerlink, .btn .rst-content h3 .headerlink, .rst-content h3 .btn .headerlink, .btn .rst-content h4 .headerlink, .rst-content h4 .btn .headerlink, .btn .rst-content h5 .headerlink, .rst-content h5 .btn .headerlink, .btn .rst-content h6 .headerlink, .rst-content h6 .btn .headerlink, .btn .rst-content dl dt .headerlink, .rst-content dl dt .btn .headerlink, .nav .icon, .nav .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success .nav .wy-input-context, .nav .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger .nav .wy-input-context, .nav .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning .nav .wy-input-context, .nav .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info .nav .wy-input-context, .nav .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag .nav .wy-tag-remove, .nav .rst-content .admonition-title, .rst-content .nav .admonition-title, .nav .rst-content h1 .headerlink, .rst-content h1 .nav .headerlink, .nav .rst-content h2 .headerlink, .rst-content h2 .nav .headerlink, .nav .rst-content h3 .headerlink, .rst-content h3 .nav .headerlink, .nav .rst-content h4 .headerlink, .rst-content h4 .nav .headerlink, .nav .rst-content h5 .headerlink, .rst-content h5 .nav .headerlink, .nav .rst-content h6 .headerlink, .rst-content h6 .nav .headerlink, .nav .rst-content dl dt .headerlink, .rst-content dl dt .nav .headerlink {
+  display: inline;
+}
+/* line 26, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn .icon.icon-large, .btn .wy-inline-validate.wy-inline-validate-success .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-success .btn .icon-large.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-danger .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-danger .btn .icon-large.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-warning .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-warning .btn .icon-large.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-info .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-info .btn .icon-large.wy-input-context, .btn .wy-tag-input-group .wy-tag .icon-large.wy-tag-remove, .wy-tag-input-group .wy-tag .btn .icon-large.wy-tag-remove, .btn .rst-content .icon-large.admonition-title, .rst-content .btn .icon-large.admonition-title, .btn .rst-content h1 .icon-large.headerlink, .rst-content h1 .btn .icon-large.headerlink, .btn .rst-content h2 .icon-large.headerlink, .rst-content h2 .btn .icon-large.headerlink, .btn .rst-content h3 .icon-large.headerlink, .rst-content h3 .btn .icon-large.headerlink, .btn .rst-content h4 .icon-large.headerlink, .rst-content h4 .btn .icon-large.headerlink, .btn .rst-content h5 .icon-large.headerlink, .rst-content h5 .btn .icon-large.headerlink, .btn .rst-content h6 .icon-large.headerlink, .rst-content h6 .btn .icon-large.headerlink, .btn .rst-content dl dt .icon-large.headerlink, .rst-content dl dt .btn .icon-large.headerlink, .nav .icon.icon-large, .nav .wy-inline-validate.wy-inline-validate-success .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-success .nav .icon-large.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-danger .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-danger .nav .icon-large.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-warning .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-warning .nav .icon-large.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-info .icon-large.wy-input-context, .wy-inline-validate.wy-inline-validate-info .nav .icon-large.wy-input-context, .nav .wy-tag-input-group .wy-tag .icon-large.wy-tag-remove, .wy-tag-input-group .wy-tag .nav .icon-large.wy-tag-remove, .nav .rst-content .icon-large.admonition-title, .rst-content .nav .icon-large.admonition-title, .nav .rst-content h1 .icon-large.headerlink, .rst-content h1 .nav .icon-large.headerlink, .nav .rst-content h2 .icon-large.headerlink, .rst-content h2 .nav .icon-large.headerlink, .nav .rst-content h3 .icon-large.headerlink, .rst-content h3 .nav .icon-large.headerlink, .nav .rst-content h4 .icon-large.headerlink, .rst-content h4 .nav .icon-large.headerlink, .nav .rst-content h5 .icon-large.headerlink, .rst-content h5 .nav .icon-large.headerlink, .nav .rst-content h6 .icon-large.headerlink, .rst-content h6 .nav .icon-large.headerlink, .nav .rst-content dl dt .icon-large.headerlink, .rst-content dl dt .nav .icon-large.headerlink {
+  line-height: 0.9em;
+}
+/* line 28, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn .icon.icon-spin, .btn .wy-inline-validate.wy-inline-validate-success .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-success .btn .icon-spin.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-danger .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-danger .btn .icon-spin.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-warning .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-warning .btn .icon-spin.wy-input-context, .btn .wy-inline-validate.wy-inline-validate-info .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-info .btn .icon-spin.wy-input-context, .btn .wy-tag-input-group .wy-tag .icon-spin.wy-tag-remove, .wy-tag-input-group .wy-tag .btn .icon-spin.wy-tag-remove, .btn .rst-content .icon-spin.admonition-title, .rst-content .btn .icon-spin.admonition-title, .btn .rst-content h1 .icon-spin.headerlink, .rst-content h1 .btn .icon-spin.headerlink, .btn .rst-content h2 .icon-spin.headerlink, .rst-content h2 .btn .icon-spin.headerlink, .btn .rst-content h3 .icon-spin.headerlink, .rst-content h3 .btn .icon-spin.headerlink, .btn .rst-content h4 .icon-spin.headerlink, .rst-content h4 .btn .icon-spin.headerlink, .btn .rst-content h5 .icon-spin.headerlink, .rst-content h5 .btn .icon-spin.headerlink, .btn .rst-content h6 .icon-spin.headerlink, .rst-content h6 .btn .icon-spin.headerlink, .btn .rst-content dl dt .icon-spin.headerlink, .rst-content dl dt .btn .icon-spin.headerlink, .nav .icon.icon-spin, .nav .wy-inline-validate.wy-inline-validate-success .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-success .nav .icon-spin.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-danger .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-danger .nav .icon-spin.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-warning .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-warning .nav .icon-spin.wy-input-context, .nav .wy-inline-validate.wy-inline-validate-info .icon-spin.wy-input-context, .wy-inline-validate.wy-inline-validate-info .nav .icon-spin.wy-input-context, .nav .wy-tag-input-group .wy-tag .icon-spin.wy-tag-remove, .wy-tag-input-group .wy-tag .nav .icon-spin.wy-tag-remove, .nav .rst-content .icon-spin.admonition-title, .rst-content .nav .icon-spin.admonition-title, .nav .rst-content h1 .icon-spin.headerlink, .rst-content h1 .nav .icon-spin.headerlink, .nav .rst-content h2 .icon-spin.headerlink, .rst-content h2 .nav .icon-spin.headerlink, .nav .rst-content h3 .icon-spin.headerlink, .rst-content h3 .nav .icon-spin.headerlink, .nav .rst-content h4 .icon-spin.headerlink, .rst-content h4 .nav .icon-spin.headerlink, .nav .rst-content h5 .icon-spin.headerlink, .rst-content h5 .nav .icon-spin.headerlink, .nav .rst-content h6 .icon-spin.headerlink, .rst-content h6 .nav .icon-spin.headerlink, .nav .rst-content dl dt .icon-spin.headerlink, .rst-content dl dt .nav .icon-spin.headerlink {
+  display: inline-block;
+}
+
+/* line 31, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn.icon:before, .wy-inline-validate.wy-inline-validate-success .btn.wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .btn.wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .btn.wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .btn.wy-input-context:before, .wy-tag-input-group .wy-tag .btn.wy-tag-remove:before, .rst-content .btn.admonition-title:before, .rst-content h1 .btn.headerlink:before, .rst-content h2 .btn.headerlink:before, .rst-content h3 .btn.headerlink:before, .rst-content h4 .btn.headerlink:before, .rst-content h5 .btn.headerlink:before, .rst-content h6 .btn.headerlink:before, .rst-content dl dt .btn.headerlink:before {
+  opacity: 0.5;
+  -webkit-transition: opacity 0.05s ease-in;
+  -moz-transition: opacity 0.05s ease-in;
+  transition: opacity 0.05s ease-in;
+}
+
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn.icon:hover:before, .wy-inline-validate.wy-inline-validate-success .btn.wy-input-context:hover:before, .wy-inline-validate.wy-inline-validate-danger .btn.wy-input-context:hover:before, .wy-inline-validate.wy-inline-validate-warning .btn.wy-input-context:hover:before, .wy-inline-validate.wy-inline-validate-info .btn.wy-input-context:hover:before, .wy-tag-input-group .wy-tag .btn.wy-tag-remove:hover:before, .rst-content .btn.admonition-title:hover:before, .rst-content h1 .btn.headerlink:hover:before, .rst-content h2 .btn.headerlink:hover:before, .rst-content h3 .btn.headerlink:hover:before, .rst-content h4 .btn.headerlink:hover:before, .rst-content h5 .btn.headerlink:hover:before, .rst-content h6 .btn.headerlink:hover:before, .rst-content dl dt .btn.headerlink:hover:before {
+  opacity: 1;
+}
+
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.btn-mini .icon:before, .btn-mini .wy-inline-validate.wy-inline-validate-success .wy-input-context:before, .wy-inline-validate.wy-inline-validate-success .btn-mini .wy-input-context:before, .btn-mini .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before, .wy-inline-validate.wy-inline-validate-danger .btn-mini .wy-input-context:before, .btn-mini .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-warning .btn-mini .wy-input-context:before, .btn-mini .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .btn-mini .wy-input-context:before, .btn-mini .wy-tag-input-group .wy-tag .wy-tag-remove:before, .wy-tag-input-group .wy-tag .btn-mini .wy-tag-remove:before, .btn-mini .rst-content .admonition-title:before, .rst-content .btn-mini .admonition-title:before, .btn-mini .rst-content h1 .headerlink:before, .rst-content h1 .btn-mini .headerlink:before, .btn-mini .rst-content h2 .headerlink:before, .rst-content h2 .btn-mini .headerlink:before, .btn-mini .rst-content h3 .headerlink:before, .rst-content h3 .btn-mini .headerlink:before, .btn-mini .rst-content h4 .headerlink:before, .rst-content h4 .btn-mini .headerlink:before, .btn-mini .rst-content h5 .headerlink:before, .rst-content h5 .btn-mini .headerlink:before, .btn-mini .rst-content h6 .headerlink:before, .rst-content h6 .btn-mini .headerlink:before, .btn-mini .rst-content dl dt .headerlink:before, .rst-content dl dt .btn-mini .headerlink:before {
+  font-size: 14px;
+  vertical-align: -15%;
+}
+
+/* line 43, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+li .icon, li .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success li .wy-input-context, li .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger li .wy-input-context, li .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning li .wy-input-context, li .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info li .wy-input-context, li .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag li .wy-tag-remove, li .rst-content .admonition-title, .rst-content li .admonition-title, li .rst-content h1 .headerlink, .rst-content h1 li .headerlink, li .rst-content h2 .headerlink, .rst-content h2 li .headerlink, li .rst-content h3 .headerlink, .rst-content h3 li .headerlink, li .rst-content h4 .headerlink, .rst-content h4 li .headerlink, li .rst-content h5 .headerlink, .rst-content h5 li .headerlink, li .rst-content h6 .headerlink, .rst-content h6 li .headerlink, li .rst-content dl dt .headerlink, .rst-content dl dt li .headerlink {
+  display: inline-block;
+}
+/* line 45, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+li .icon-large:before,
+li .icon-large:before {
+  /* 1.5 increased font size for icon-large * 1.25 width */
+  width: 1.875em;
+}
+
+/* line 50, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+ul.icons {
+  list-style-type: none;
+  margin-left: 2em;
+  text-indent: -0.8em;
+}
+/* line 55, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+ul.icons li .icon, ul.icons li .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success ul.icons li .wy-input-context, ul.icons li .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger ul.icons li .wy-input-context, ul.icons li .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning ul.icons li .wy-input-context, ul.icons li .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info ul.icons li .wy-input-context, ul.icons li .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag ul.icons li .wy-tag-remove, ul.icons li .rst-content .admonition-title, .rst-content ul.icons li .admonition-title, ul.icons li .rst-content h1 .headerlink, .rst-content h1 ul.icons li .headerlink, ul.icons li .rst-content h2 .headerlink, .rst-content h2 ul.icons li .headerlink, ul.icons li .rst-content h3 .headerlink, .rst-content h3 ul.icons li .headerlink, ul.icons li .rst-content h4 .headerlink, .rst-content h4 ul.icons li .headerlink, ul.icons li .rst-content h5 .headerlink, .rst-content h5 ul.icons li .headerlink, ul.icons li .rst-content h6 .headerlink, .rst-content h6 ul.icons li .headerlink, ul.icons li .rst-content dl dt .headerlink, .rst-content dl dt ul.icons li .headerlink {
+  width: 0.8em;
+}
+/* line 57, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+ul.icons li .icon-large:before,
+ul.icons li .icon-large:before {
+  /* 1.5 increased font size for icon-large * 1.25 width */
+  vertical-align: baseline;
+}
+
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-glass:before {
+  content: "\f000";
+}
+
+/* line 68, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-music:before {
+  content: "\f001";
+}
+
+/* line 71, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-search:before {
+  content: "\f002";
+}
+
+/* line 74, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-envelope-alt:before {
+  content: "\f003";
+}
+
+/* line 77, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-heart:before {
+  content: "\f004";
+}
+
+/* line 80, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-star:before {
+  content: "\f005";
+}
+
+/* line 83, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-star-empty:before {
+  content: "\f006";
+}
+
+/* line 86, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-user:before {
+  content: "\f007";
+}
+
+/* line 89, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-film:before {
+  content: "\f008";
+}
+
+/* line 92, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-th-large:before {
+  content: "\f009";
+}
+
+/* line 95, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-th:before {
+  content: "\f00a";
+}
+
+/* line 98, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-th-list:before {
+  content: "\f00b";
+}
+
+/* line 101, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ok:before {
+  content: "\f00c";
+}
+
+/* line 104, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-remove:before, .wy-tag-input-group .wy-tag .wy-tag-remove:before {
+  content: "\f00d";
+}
+
+/* line 107, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-zoom-in:before {
+  content: "\f00e";
+}
+
+/* line 110, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-zoom-out:before {
+  content: "\f010";
+}
+
+/* line 113, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-power-off:before,
+.icon-off:before {
+  content: "\f011";
+}
+
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-signal:before {
+  content: "\f012";
+}
+
+/* line 120, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gear:before,
+.icon-cog:before {
+  content: "\f013";
+}
+
+/* line 124, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-trash:before {
+  content: "\f014";
+}
+
+/* line 127, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-home:before {
+  content: "\f015";
+}
+
+/* line 130, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-file-alt:before {
+  content: "\f016";
+}
+
+/* line 133, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-time:before {
+  content: "\f017";
+}
+
+/* line 136, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-road:before {
+  content: "\f018";
+}
+
+/* line 139, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-download-alt:before {
+  content: "\f019";
+}
+
+/* line 142, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-download:before {
+  content: "\f01a";
+}
+
+/* line 145, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-upload:before {
+  content: "\f01b";
+}
+
+/* line 148, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-inbox:before {
+  content: "\f01c";
+}
+
+/* line 151, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-play-circle:before {
+  content: "\f01d";
+}
+
+/* line 154, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rotate-right:before,
+.icon-repeat:before {
+  content: "\f01e";
+}
+
+/* line 158, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-refresh:before {
+  content: "\f021";
+}
+
+/* line 161, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-list-alt:before {
+  content: "\f022";
+}
+
+/* line 164, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-lock:before {
+  content: "\f023";
+}
+
+/* line 167, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-flag:before {
+  content: "\f024";
+}
+
+/* line 170, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-headphones:before {
+  content: "\f025";
+}
+
+/* line 173, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-volume-off:before {
+  content: "\f026";
+}
+
+/* line 176, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-volume-down:before {
+  content: "\f027";
+}
+
+/* line 179, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-volume-up:before {
+  content: "\f028";
+}
+
+/* line 182, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-qrcode:before {
+  content: "\f029";
+}
+
+/* line 185, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-barcode:before {
+  content: "\f02a";
+}
+
+/* line 188, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tag:before {
+  content: "\f02b";
+}
+
+/* line 191, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tags:before {
+  content: "\f02c";
+}
+
+/* line 194, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-book:before {
+  content: "\f02d";
+}
+
+/* line 197, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bookmark:before {
+  content: "\f02e";
+}
+
+/* line 200, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-print:before {
+  content: "\f02f";
+}
+
+/* line 203, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-camera:before {
+  content: "\f030";
+}
+
+/* line 206, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-font:before {
+  content: "\f031";
+}
+
+/* line 209, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bold:before {
+  content: "\f032";
+}
+
+/* line 212, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-italic:before {
+  content: "\f033";
+}
+
+/* line 215, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-text-height:before {
+  content: "\f034";
+}
+
+/* line 218, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-text-width:before {
+  content: "\f035";
+}
+
+/* line 221, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-align-left:before {
+  content: "\f036";
+}
+
+/* line 224, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-align-center:before {
+  content: "\f037";
+}
+
+/* line 227, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-align-right:before {
+  content: "\f038";
+}
+
+/* line 230, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-align-justify:before {
+  content: "\f039";
+}
+
+/* line 233, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-list:before {
+  content: "\f03a";
+}
+
+/* line 236, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-indent-left:before {
+  content: "\f03b";
+}
+
+/* line 239, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-indent-right:before {
+  content: "\f03c";
+}
+
+/* line 242, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-facetime-video:before {
+  content: "\f03d";
+}
+
+/* line 245, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-picture:before {
+  content: "\f03e";
+}
+
+/* line 248, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-pencil:before {
+  content: "\f040";
+}
+
+/* line 251, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-map-marker:before {
+  content: "\f041";
+}
+
+/* line 254, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-adjust:before {
+  content: "\f042";
+}
+
+/* line 257, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tint:before {
+  content: "\f043";
+}
+
+/* line 260, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-edit:before {
+  content: "\f044";
+}
+
+/* line 263, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-share:before {
+  content: "\f045";
+}
+
+/* line 266, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-check:before {
+  content: "\f046";
+}
+
+/* line 269, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-move:before {
+  content: "\f047";
+}
+
+/* line 272, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-step-backward:before {
+  content: "\f048";
+}
+
+/* line 275, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fast-backward:before {
+  content: "\f049";
+}
+
+/* line 278, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-backward:before {
+  content: "\f04a";
+}
+
+/* line 281, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-play:before {
+  content: "\f04b";
+}
+
+/* line 284, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-pause:before {
+  content: "\f04c";
+}
+
+/* line 287, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-stop:before {
+  content: "\f04d";
+}
+
+/* line 290, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-forward:before {
+  content: "\f04e";
+}
+
+/* line 293, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fast-forward:before {
+  content: "\f050";
+}
+
+/* line 296, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-step-forward:before {
+  content: "\f051";
+}
+
+/* line 299, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-eject:before {
+  content: "\f052";
+}
+
+/* line 302, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-left:before {
+  content: "\f053";
+}
+
+/* line 305, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-right:before {
+  content: "\f054";
+}
+
+/* line 308, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-plus-sign:before {
+  content: "\f055";
+}
+
+/* line 311, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-minus-sign:before {
+  content: "\f056";
+}
+
+/* line 314, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-remove-sign:before, .wy-inline-validate.wy-inline-validate-danger .wy-input-context:before {
+  content: "\f057";
+}
+
+/* line 317, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ok-sign:before {
+  content: "\f058";
+}
+
+/* line 320, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-question-sign:before {
+  content: "\f059";
+}
+
+/* line 323, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-info-sign:before {
+  content: "\f05a";
+}
+
+/* line 326, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-screenshot:before {
+  content: "\f05b";
+}
+
+/* line 329, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-remove-circle:before {
+  content: "\f05c";
+}
+
+/* line 332, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ok-circle:before {
+  content: "\f05d";
+}
+
+/* line 335, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ban-circle:before {
+  content: "\f05e";
+}
+
+/* line 338, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-arrow-left:before {
+  content: "\f060";
+}
+
+/* line 341, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-arrow-right:before {
+  content: "\f061";
+}
+
+/* line 344, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-arrow-up:before {
+  content: "\f062";
+}
+
+/* line 347, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-arrow-down:before {
+  content: "\f063";
+}
+
+/* line 350, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-mail-forward:before,
+.icon-share-alt:before {
+  content: "\f064";
+}
+
+/* line 354, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-resize-full:before {
+  content: "\f065";
+}
+
+/* line 357, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-resize-small:before {
+  content: "\f066";
+}
+
+/* line 360, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-plus:before {
+  content: "\f067";
+}
+
+/* line 363, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-minus:before {
+  content: "\f068";
+}
+
+/* line 366, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-asterisk:before {
+  content: "\f069";
+}
+
+/* line 369, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-exclamation-sign:before, .wy-inline-validate.wy-inline-validate-warning .wy-input-context:before, .wy-inline-validate.wy-inline-validate-info .wy-input-context:before, .rst-content .admonition-title:before {
+  content: "\f06a";
+}
+
+/* line 372, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gift:before {
+  content: "\f06b";
+}
+
+/* line 375, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-leaf:before {
+  content: "\f06c";
+}
+
+/* line 378, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fire:before {
+  content: "\f06d";
+}
+
+/* line 381, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-eye-open:before {
+  content: "\f06e";
+}
+
+/* line 384, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-eye-close:before {
+  content: "\f070";
+}
+
+/* line 387, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-warning-sign:before {
+  content: "\f071";
+}
+
+/* line 390, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-plane:before {
+  content: "\f072";
+}
+
+/* line 393, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-calendar:before {
+  content: "\f073";
+}
+
+/* line 396, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-random:before {
+  content: "\f074";
+}
+
+/* line 399, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-comment:before {
+  content: "\f075";
+}
+
+/* line 402, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-magnet:before {
+  content: "\f076";
+}
+
+/* line 405, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-up:before {
+  content: "\f077";
+}
+
+/* line 408, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-down:before {
+  content: "\f078";
+}
+
+/* line 411, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-retweet:before {
+  content: "\f079";
+}
+
+/* line 414, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-shopping-cart:before {
+  content: "\f07a";
+}
+
+/* line 417, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-folder-close:before {
+  content: "\f07b";
+}
+
+/* line 420, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-folder-open:before {
+  content: "\f07c";
+}
+
+/* line 423, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-resize-vertical:before {
+  content: "\f07d";
+}
+
+/* line 426, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-resize-horizontal:before {
+  content: "\f07e";
+}
+
+/* line 429, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bar-chart:before {
+  content: "\f080";
+}
+
+/* line 432, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-twitter-sign:before {
+  content: "\f081";
+}
+
+/* line 435, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-facebook-sign:before {
+  content: "\f082";
+}
+
+/* line 438, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-camera-retro:before {
+  content: "\f083";
+}
+
+/* line 441, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-key:before {
+  content: "\f084";
+}
+
+/* line 444, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gears:before,
+.icon-cogs:before {
+  content: "\f085";
+}
+
+/* line 448, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-comments:before {
+  content: "\f086";
+}
+
+/* line 451, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-thumbs-up-alt:before {
+  content: "\f087";
+}
+
+/* line 454, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-thumbs-down-alt:before {
+  content: "\f088";
+}
+
+/* line 457, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-star-half:before {
+  content: "\f089";
+}
+
+/* line 460, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-heart-empty:before {
+  content: "\f08a";
+}
+
+/* line 463, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-signout:before {
+  content: "\f08b";
+}
+
+/* line 466, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-linkedin-sign:before {
+  content: "\f08c";
+}
+
+/* line 469, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-pushpin:before {
+  content: "\f08d";
+}
+
+/* line 472, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-external-link:before {
+  content: "\f08e";
+}
+
+/* line 475, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-signin:before {
+  content: "\f090";
+}
+
+/* line 478, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-trophy:before {
+  content: "\f091";
+}
+
+/* line 481, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-github-sign:before {
+  content: "\f092";
+}
+
+/* line 484, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-upload-alt:before {
+  content: "\f093";
+}
+
+/* line 487, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-lemon:before {
+  content: "\f094";
+}
+
+/* line 490, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-phone:before {
+  content: "\f095";
+}
+
+/* line 493, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-unchecked:before,
+.icon-check-empty:before {
+  content: "\f096";
+}
+
+/* line 497, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bookmark-empty:before {
+  content: "\f097";
+}
+
+/* line 500, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-phone-sign:before {
+  content: "\f098";
+}
+
+/* line 503, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-twitter:before {
+  content: "\f099";
+}
+
+/* line 506, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-facebook:before {
+  content: "\f09a";
+}
+
+/* line 509, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-github:before {
+  content: "\f09b";
+}
+
+/* line 512, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-unlock:before {
+  content: "\f09c";
+}
+
+/* line 515, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-credit-card:before {
+  content: "\f09d";
+}
+
+/* line 518, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rss:before {
+  content: "\f09e";
+}
+
+/* line 521, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hdd:before {
+  content: "\f0a0";
+}
+
+/* line 524, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bullhorn:before {
+  content: "\f0a1";
+}
+
+/* line 527, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bell:before {
+  content: "\f0a2";
+}
+
+/* line 530, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-certificate:before {
+  content: "\f0a3";
+}
+
+/* line 533, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hand-right:before {
+  content: "\f0a4";
+}
+
+/* line 536, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hand-left:before {
+  content: "\f0a5";
+}
+
+/* line 539, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hand-up:before {
+  content: "\f0a6";
+}
+
+/* line 542, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hand-down:before {
+  content: "\f0a7";
+}
+
+/* line 545, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle-arrow-left:before {
+  content: "\f0a8";
+}
+
+/* line 548, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle-arrow-right:before {
+  content: "\f0a9";
+}
+
+/* line 551, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle-arrow-up:before {
+  content: "\f0aa";
+}
+
+/* line 554, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle-arrow-down:before {
+  content: "\f0ab";
+}
+
+/* line 557, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-globe:before {
+  content: "\f0ac";
+}
+
+/* line 560, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-wrench:before {
+  content: "\f0ad";
+}
+
+/* line 563, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tasks:before {
+  content: "\f0ae";
+}
+
+/* line 566, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-filter:before {
+  content: "\f0b0";
+}
+
+/* line 569, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-briefcase:before {
+  content: "\f0b1";
+}
+
+/* line 572, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fullscreen:before {
+  content: "\f0b2";
+}
+
+/* line 575, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-group:before {
+  content: "\f0c0";
+}
+
+/* line 578, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-link:before {
+  content: "\f0c1";
+}
+
+/* line 581, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-cloud:before {
+  content: "\f0c2";
+}
+
+/* line 584, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-beaker:before {
+  content: "\f0c3";
+}
+
+/* line 587, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-cut:before {
+  content: "\f0c4";
+}
+
+/* line 590, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-copy:before {
+  content: "\f0c5";
+}
+
+/* line 593, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-paperclip:before,
+.icon-paper-clip:before {
+  content: "\f0c6";
+}
+
+/* line 597, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-save:before {
+  content: "\f0c7";
+}
+
+/* line 600, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sign-blank:before {
+  content: "\f0c8";
+}
+
+/* line 603, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-reorder:before {
+  content: "\f0c9";
+}
+
+/* line 606, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-list-ul:before {
+  content: "\f0ca";
+}
+
+/* line 609, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-list-ol:before {
+  content: "\f0cb";
+}
+
+/* line 612, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-strikethrough:before {
+  content: "\f0cc";
+}
+
+/* line 615, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-underline:before {
+  content: "\f0cd";
+}
+
+/* line 618, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-table:before {
+  content: "\f0ce";
+}
+
+/* line 621, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-magic:before {
+  content: "\f0d0";
+}
+
+/* line 624, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-truck:before {
+  content: "\f0d1";
+}
+
+/* line 627, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-pinterest:before {
+  content: "\f0d2";
+}
+
+/* line 630, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-pinterest-sign:before {
+  content: "\f0d3";
+}
+
+/* line 633, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-google-plus-sign:before {
+  content: "\f0d4";
+}
+
+/* line 636, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-google-plus:before {
+  content: "\f0d5";
+}
+
+/* line 639, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-money:before {
+  content: "\f0d6";
+}
+
+/* line 642, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-caret-down:before {
+  content: "\f0d7";
+}
+
+/* line 645, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-caret-up:before {
+  content: "\f0d8";
+}
+
+/* line 648, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-caret-left:before {
+  content: "\f0d9";
+}
+
+/* line 651, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-caret-right:before {
+  content: "\f0da";
+}
+
+/* line 654, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-columns:before {
+  content: "\f0db";
+}
+
+/* line 657, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort:before {
+  content: "\f0dc";
+}
+
+/* line 660, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-down:before {
+  content: "\f0dd";
+}
+
+/* line 663, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-up:before {
+  content: "\f0de";
+}
+
+/* line 666, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-envelope:before {
+  content: "\f0e0";
+}
+
+/* line 669, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-linkedin:before {
+  content: "\f0e1";
+}
+
+/* line 672, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rotate-left:before,
+.icon-undo:before {
+  content: "\f0e2";
+}
+
+/* line 676, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-legal:before {
+  content: "\f0e3";
+}
+
+/* line 679, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-dashboard:before {
+  content: "\f0e4";
+}
+
+/* line 682, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-comment-alt:before {
+  content: "\f0e5";
+}
+
+/* line 685, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-comments-alt:before {
+  content: "\f0e6";
+}
+
+/* line 688, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bolt:before {
+  content: "\f0e7";
+}
+
+/* line 691, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sitemap:before {
+  content: "\f0e8";
+}
+
+/* line 694, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-umbrella:before {
+  content: "\f0e9";
+}
+
+/* line 697, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-paste:before {
+  content: "\f0ea";
+}
+
+/* line 700, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-lightbulb:before {
+  content: "\f0eb";
+}
+
+/* line 703, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-exchange:before {
+  content: "\f0ec";
+}
+
+/* line 706, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-cloud-download:before {
+  content: "\f0ed";
+}
+
+/* line 709, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-cloud-upload:before {
+  content: "\f0ee";
+}
+
+/* line 712, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-user-md:before {
+  content: "\f0f0";
+}
+
+/* line 715, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-stethoscope:before {
+  content: "\f0f1";
+}
+
+/* line 718, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-suitcase:before {
+  content: "\f0f2";
+}
+
+/* line 721, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bell-alt:before {
+  content: "\f0f3";
+}
+
+/* line 724, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-coffee:before {
+  content: "\f0f4";
+}
+
+/* line 727, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-food:before {
+  content: "\f0f5";
+}
+
+/* line 730, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-file-text-alt:before {
+  content: "\f0f6";
+}
+
+/* line 733, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-building:before {
+  content: "\f0f7";
+}
+
+/* line 736, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-hospital:before {
+  content: "\f0f8";
+}
+
+/* line 739, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ambulance:before {
+  content: "\f0f9";
+}
+
+/* line 742, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-medkit:before {
+  content: "\f0fa";
+}
+
+/* line 745, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fighter-jet:before {
+  content: "\f0fb";
+}
+
+/* line 748, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-beer:before {
+  content: "\f0fc";
+}
+
+/* line 751, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-h-sign:before {
+  content: "\f0fd";
+}
+
+/* line 754, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-plus-sign-alt:before {
+  content: "\f0fe";
+}
+
+/* line 757, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-double-angle-left:before {
+  content: "\f100";
+}
+
+/* line 760, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-double-angle-right:before {
+  content: "\f101";
+}
+
+/* line 763, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-double-angle-up:before {
+  content: "\f102";
+}
+
+/* line 766, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-double-angle-down:before {
+  content: "\f103";
+}
+
+/* line 769, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-angle-left:before {
+  content: "\f104";
+}
+
+/* line 772, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-angle-right:before {
+  content: "\f105";
+}
+
+/* line 775, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-angle-up:before {
+  content: "\f106";
+}
+
+/* line 778, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-angle-down:before {
+  content: "\f107";
+}
+
+/* line 781, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-desktop:before {
+  content: "\f108";
+}
+
+/* line 784, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-laptop:before {
+  content: "\f109";
+}
+
+/* line 787, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tablet:before {
+  content: "\f10a";
+}
+
+/* line 790, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-mobile-phone:before {
+  content: "\f10b";
+}
+
+/* line 793, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle-blank:before {
+  content: "\f10c";
+}
+
+/* line 796, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-quote-left:before {
+  content: "\f10d";
+}
+
+/* line 799, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-quote-right:before {
+  content: "\f10e";
+}
+
+/* line 802, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-spinner:before {
+  content: "\f110";
+}
+
+/* line 805, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-circle:before {
+  content: "\f111";
+}
+
+/* line 808, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-mail-reply:before,
+.icon-reply:before {
+  content: "\f112";
+}
+
+/* line 812, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-github-alt:before {
+  content: "\f113";
+}
+
+/* line 815, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-folder-close-alt:before {
+  content: "\f114";
+}
+
+/* line 818, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-folder-open-alt:before {
+  content: "\f115";
+}
+
+/* line 821, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-expand-alt:before {
+  content: "\f116";
+}
+
+/* line 824, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-collapse-alt:before {
+  content: "\f117";
+}
+
+/* line 827, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-smile:before {
+  content: "\f118";
+}
+
+/* line 830, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-frown:before {
+  content: "\f119";
+}
+
+/* line 833, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-meh:before {
+  content: "\f11a";
+}
+
+/* line 836, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gamepad:before {
+  content: "\f11b";
+}
+
+/* line 839, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-keyboard:before {
+  content: "\f11c";
+}
+
+/* line 842, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-flag-alt:before {
+  content: "\f11d";
+}
+
+/* line 845, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-flag-checkered:before {
+  content: "\f11e";
+}
+
+/* line 848, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-terminal:before {
+  content: "\f120";
+}
+
+/* line 851, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-code:before {
+  content: "\f121";
+}
+
+/* line 854, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-reply-all:before {
+  content: "\f122";
+}
+
+/* line 857, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-mail-reply-all:before {
+  content: "\f122";
+}
+
+/* line 860, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-star-half-full:before,
+.icon-star-half-empty:before {
+  content: "\f123";
+}
+
+/* line 864, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-location-arrow:before {
+  content: "\f124";
+}
+
+/* line 867, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-crop:before {
+  content: "\f125";
+}
+
+/* line 870, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-code-fork:before {
+  content: "\f126";
+}
+
+/* line 873, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-unlink:before {
+  content: "\f127";
+}
+
+/* line 876, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-question:before {
+  content: "\f128";
+}
+
+/* line 879, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-info:before {
+  content: "\f129";
+}
+
+/* line 882, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-exclamation:before {
+  content: "\f12a";
+}
+
+/* line 885, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-superscript:before {
+  content: "\f12b";
+}
+
+/* line 888, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-subscript:before {
+  content: "\f12c";
+}
+
+/* line 891, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-eraser:before {
+  content: "\f12d";
+}
+
+/* line 894, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-puzzle-piece:before {
+  content: "\f12e";
+}
+
+/* line 897, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-microphone:before {
+  content: "\f130";
+}
+
+/* line 900, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-microphone-off:before {
+  content: "\f131";
+}
+
+/* line 903, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-shield:before {
+  content: "\f132";
+}
+
+/* line 906, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-calendar-empty:before {
+  content: "\f133";
+}
+
+/* line 909, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-fire-extinguisher:before {
+  content: "\f134";
+}
+
+/* line 912, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rocket:before {
+  content: "\f135";
+}
+
+/* line 915, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-maxcdn:before {
+  content: "\f136";
+}
+
+/* line 918, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-sign-left:before {
+  content: "\f137";
+}
+
+/* line 921, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-sign-right:before {
+  content: "\f138";
+}
+
+/* line 924, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-sign-up:before {
+  content: "\f139";
+}
+
+/* line 927, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-chevron-sign-down:before {
+  content: "\f13a";
+}
+
+/* line 930, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-html5:before {
+  content: "\f13b";
+}
+
+/* line 933, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-css3:before {
+  content: "\f13c";
+}
+
+/* line 936, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-anchor:before {
+  content: "\f13d";
+}
+
+/* line 939, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-unlock-alt:before {
+  content: "\f13e";
+}
+
+/* line 942, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bullseye:before {
+  content: "\f140";
+}
+
+/* line 945, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ellipsis-horizontal:before {
+  content: "\f141";
+}
+
+/* line 948, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ellipsis-vertical:before {
+  content: "\f142";
+}
+
+/* line 951, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rss-sign:before {
+  content: "\f143";
+}
+
+/* line 954, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-play-sign:before {
+  content: "\f144";
+}
+
+/* line 957, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-ticket:before {
+  content: "\f145";
+}
+
+/* line 960, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-minus-sign-alt:before {
+  content: "\f146";
+}
+
+/* line 963, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-check-minus:before {
+  content: "\f147";
+}
+
+/* line 966, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-level-up:before {
+  content: "\f148";
+}
+
+/* line 969, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-level-down:before {
+  content: "\f149";
+}
+
+/* line 972, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-check-sign:before, .wy-inline-validate.wy-inline-validate-success .wy-input-context:before {
+  content: "\f14a";
+}
+
+/* line 975, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-edit-sign:before {
+  content: "\f14b";
+}
+
+/* line 978, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-external-link-sign:before {
+  content: "\f14c";
+}
+
+/* line 981, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-share-sign:before {
+  content: "\f14d";
+}
+
+/* line 984, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-compass:before {
+  content: "\f14e";
+}
+
+/* line 987, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-collapse:before {
+  content: "\f150";
+}
+
+/* line 990, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-collapse-top:before {
+  content: "\f151";
+}
+
+/* line 993, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-expand:before {
+  content: "\f152";
+}
+
+/* line 996, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-euro:before,
+.icon-eur:before {
+  content: "\f153";
+}
+
+/* line 1000, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gbp:before {
+  content: "\f154";
+}
+
+/* line 1003, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-dollar:before,
+.icon-usd:before {
+  content: "\f155";
+}
+
+/* line 1007, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-rupee:before,
+.icon-inr:before {
+  content: "\f156";
+}
+
+/* line 1011, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-yen:before,
+.icon-jpy:before {
+  content: "\f157";
+}
+
+/* line 1015, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-renminbi:before,
+.icon-cny:before {
+  content: "\f158";
+}
+
+/* line 1019, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-won:before,
+.icon-krw:before {
+  content: "\f159";
+}
+
+/* line 1023, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bitcoin:before,
+.icon-btc:before {
+  content: "\f15a";
+}
+
+/* line 1027, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-file:before {
+  content: "\f15b";
+}
+
+/* line 1030, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-file-text:before {
+  content: "\f15c";
+}
+
+/* line 1033, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-alphabet:before {
+  content: "\f15d";
+}
+
+/* line 1036, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-alphabet-alt:before {
+  content: "\f15e";
+}
+
+/* line 1039, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-attributes:before {
+  content: "\f160";
+}
+
+/* line 1042, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-attributes-alt:before {
+  content: "\f161";
+}
+
+/* line 1045, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-order:before {
+  content: "\f162";
+}
+
+/* line 1048, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sort-by-order-alt:before {
+  content: "\f163";
+}
+
+/* line 1051, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-thumbs-up:before {
+  content: "\f164";
+}
+
+/* line 1054, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-thumbs-down:before {
+  content: "\f165";
+}
+
+/* line 1057, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-youtube-sign:before {
+  content: "\f166";
+}
+
+/* line 1060, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-youtube:before {
+  content: "\f167";
+}
+
+/* line 1063, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-xing:before {
+  content: "\f168";
+}
+
+/* line 1066, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-xing-sign:before {
+  content: "\f169";
+}
+
+/* line 1069, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-youtube-play:before {
+  content: "\f16a";
+}
+
+/* line 1072, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-dropbox:before {
+  content: "\f16b";
+}
+
+/* line 1075, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-stackexchange:before {
+  content: "\f16c";
+}
+
+/* line 1078, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-instagram:before {
+  content: "\f16d";
+}
+
+/* line 1081, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-flickr:before {
+  content: "\f16e";
+}
+
+/* line 1084, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-adn:before {
+  content: "\f170";
+}
+
+/* line 1087, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bitbucket:before {
+  content: "\f171";
+}
+
+/* line 1090, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bitbucket-sign:before {
+  content: "\f172";
+}
+
+/* line 1093, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tumblr:before {
+  content: "\f173";
+}
+
+/* line 1096, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-tumblr-sign:before {
+  content: "\f174";
+}
+
+/* line 1099, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-long-arrow-down:before {
+  content: "\f175";
+}
+
+/* line 1102, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-long-arrow-up:before {
+  content: "\f176";
+}
+
+/* line 1105, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-long-arrow-left:before {
+  content: "\f177";
+}
+
+/* line 1108, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-long-arrow-right:before {
+  content: "\f178";
+}
+
+/* line 1111, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-apple:before {
+  content: "\f179";
+}
+
+/* line 1114, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-windows:before {
+  content: "\f17a";
+}
+
+/* line 1117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-android:before {
+  content: "\f17b";
+}
+
+/* line 1120, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-linux:before {
+  content: "\f17c";
+}
+
+/* line 1123, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-dribbble:before {
+  content: "\f17d";
+}
+
+/* line 1126, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-skype:before {
+  content: "\f17e";
+}
+
+/* line 1129, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-foursquare:before {
+  content: "\f180";
+}
+
+/* line 1132, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-trello:before {
+  content: "\f181";
+}
+
+/* line 1135, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-female:before {
+  content: "\f182";
+}
+
+/* line 1138, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-male:before {
+  content: "\f183";
+}
+
+/* line 1141, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-gittip:before {
+  content: "\f184";
+}
+
+/* line 1144, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-sun:before {
+  content: "\f185";
+}
+
+/* line 1147, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-moon:before {
+  content: "\f186";
+}
+
+/* line 1150, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-archive:before {
+  content: "\f187";
+}
+
+/* line 1153, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-bug:before {
+  content: "\f188";
+}
+
+/* line 1156, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-vk:before {
+  content: "\f189";
+}
+
+/* line 1159, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-weibo:before {
+  content: "\f18a";
+}
+
+/* line 1162, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_font_awesome.sass */
+.icon-renren:before {
+  content: "\f18b";
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert, .rst-content .note, .rst-content .attention, .rst-content .caution, .rst-content .danger, .rst-content .error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .warning {
+  padding: 24px;
+  line-height: 24px;
+  margin-bottom: 24px;
+  border-left: solid 3px transparent;
+}
+/* line 7, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert strong, .rst-content .note strong, .rst-content .attention strong, .rst-content .caution strong, .rst-content .danger strong, .rst-content .error strong, .rst-content .hint strong, .rst-content .important strong, .rst-content .tip strong, .rst-content .warning strong, .wy-alert a, .rst-content .note a, .rst-content .attention a, .rst-content .caution a, .rst-content .danger a, .rst-content .error a, .rst-content .hint a, .rst-content .important a, .rst-content .tip a, .rst-content .warning a {
+  color: white;
+}
+
+/* line 10, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-danger, .rst-content .wy-alert-danger.note, .rst-content .wy-alert-danger.attention, .rst-content .wy-alert-danger.caution, .rst-content .danger, .rst-content .error, .rst-content .wy-alert-danger.hint, .rst-content .wy-alert-danger.important, .rst-content .wy-alert-danger.tip, .rst-content .wy-alert-danger.warning {
+  background: #e74c3c;
+  color: white;
+  border-color: #d62c1a;
+}
+
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-warning, .rst-content .wy-alert-warning.note, .rst-content .attention, .rst-content .caution, .rst-content .wy-alert-warning.danger, .rst-content .wy-alert-warning.error, .rst-content .wy-alert-warning.hint, .rst-content .wy-alert-warning.important, .rst-content .wy-alert-warning.tip, .rst-content .warning {
+  background: #e67e22;
+  color: white;
+  border-color: #bf6516;
+}
+
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-info, .rst-content .note, .rst-content .wy-alert-info.attention, .rst-content .wy-alert-info.caution, .rst-content .wy-alert-info.danger, .rst-content .wy-alert-info.error, .rst-content .hint, .rst-content .important, .rst-content .tip, .rst-content .wy-alert-info.warning {
+  background: #2980b9;
+  color: white;
+  border-color: #20638f;
+}
+
+/* line 24, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-success, .rst-content .wy-alert-success.note, .rst-content .wy-alert-success.attention, .rst-content .wy-alert-success.caution, .rst-content .wy-alert-success.danger, .rst-content .wy-alert-success.error, .rst-content .wy-alert-success.hint, .rst-content .wy-alert-success.important, .rst-content .wy-alert-success.tip, .rst-content .wy-alert-success.warning {
+  background: #27ae60;
+  color: white;
+  border-color: #1e8449;
+}
+
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-neutral, .rst-content .wy-alert-neutral.note, .rst-content .wy-alert-neutral.attention, .rst-content .wy-alert-neutral.caution, .rst-content .wy-alert-neutral.danger, .rst-content .wy-alert-neutral.error, .rst-content .wy-alert-neutral.hint, .rst-content .wy-alert-neutral.important, .rst-content .wy-alert-neutral.tip, .rst-content .wy-alert-neutral.warning {
+  background: #f3f6f6;
+  border-color: #e1e4e5;
+}
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-neutral strong, .rst-content .wy-alert-neutral.note strong, .rst-content .wy-alert-neutral.attention strong, .rst-content .wy-alert-neutral.caution strong, .rst-content .wy-alert-neutral.danger strong, .rst-content .wy-alert-neutral.error strong, .rst-content .wy-alert-neutral.hint strong, .rst-content .wy-alert-neutral.important strong, .rst-content .wy-alert-neutral.tip strong, .rst-content .wy-alert-neutral.warning strong {
+  color: #404040;
+}
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-alert.wy-alert-neutral a, .rst-content .wy-alert-neutral.note a, .rst-content .wy-alert-neutral.attention a, .rst-content .wy-alert-neutral.caution a, .rst-content .wy-alert-neutral.danger a, .rst-content .wy-alert-neutral.error a, .rst-content .wy-alert-neutral.hint a, .rst-content .wy-alert-neutral.important a, .rst-content .wy-alert-neutral.tip a, .rst-content .wy-alert-neutral.warning a {
+  color: #2980b9;
+}
+
+/* line 37, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container {
+  position: fixed;
+  top: -50px;
+  left: 0;
+  width: 100%;
+  -webkit-transition: top 0.2s ease-in;
+  -moz-transition: top 0.2s ease-in;
+  transition: top 0.2s ease-in;
+}
+/* line 43, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container.on {
+  top: 0;
+}
+/* line 45, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container li {
+  display: none;
+  width: 100%;
+  background: #343131;
+  padding: 12px 24px;
+  color: white;
+  margin-bottom: 6px;
+  text-align: center;
+  box-shadow: 0 5px 5px 0 rgba(0, 0, 0, 0.1), 0px -1px 2px -1px rgba(255, 255, 255, 0.5) inset;
+}
+/* line 54, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container li.wy-tray-item-success {
+  background: #27ae60;
+}
+/* line 56, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container li.wy-tray-item-info {
+  background: #2980b9;
+}
+/* line 58, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container li.wy-tray-item-warning {
+  background: #e67e22;
+}
+/* line 60, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_alert.sass */
+.wy-tray-container li.wy-tray-item-danger {
+  background: #e74c3c;
+}
+
+/* line 4, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn {
+  /* Structure */
+  display: inline-block;
+  *display: inline;
+  /*IE 6/7 */
+  zoom: 1;
+  line-height: normal;
+  white-space: nowrap;
+  vertical-align: baseline;
+  text-align: center;
+  cursor: pointer;
+  -webkit-user-drag: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  font-size: 100%;
+  padding: 6px 12px;
+  color: white;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-bottom: solid 3px rgba(0, 0, 0, 0.1);
+  background-color: #27ae60;
+  text-decoration: none;
+  font-weight: 500;
+  box-shadow: 0px 1px 2px -1px rgba(255, 255, 255, 0.5) inset;
+  -webkit-transition: all 0.1s linear;
+  -moz-transition: all 0.1s linear;
+  transition: all 0.1s linear;
+  outline-none: false;
+}
+
+/* line 30, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-hover {
+  background: #2e8ece;
+  color: white;
+}
+
+/* line 35, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn:hover {
+  background: #2cc36b;
+  color: white;
+}
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn:focus {
+  background: #2cc36b;
+  color: white;
+  outline: 0;
+}
+/* line 42, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn:active {
+  border-top: solid 3px rgba(0, 0, 0, 0.1);
+  border-bottom: solid 1px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 1px 2px -1px rgba(0, 0, 0, 0.5) inset;
+}
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn[disabled] {
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: alpha(opacity=40);
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* line 54, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-disabled {
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: alpha(opacity=40);
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+/* line 61, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-disabled:hover, .btn-disabled:focus, .btn-disabled:active {
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  filter: alpha(opacity=40);
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+/* Firefox: Get rid of the inner focus border */
+/* line 71, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+
+/* line 75, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-small {
+  font-size: 80%;
+}
+
+/* line 78, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-info {
+  background-color: #2980b9 !important;
+}
+/* line 80, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-info:hover {
+  background-color: #2e8ece !important;
+}
+
+/* line 83, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-neutral {
+  background-color: #f3f6f6 !important;
+  color: #404040 !important;
+}
+/* line 86, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-neutral:hover {
+  background-color: #e5ebeb !important;
+  color: #404040;
+}
+
+/* line 90, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-danger {
+  background-color: #e74c3c !important;
+}
+/* line 92, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-danger:hover {
+  background-color: #ea6153 !important;
+}
+
+/* line 95, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-warning {
+  background-color: #e67e22 !important;
+}
+/* line 97, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-warning:hover {
+  background-color: #e98b39 !important;
+}
+
+/* line 99, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-invert {
+  background-color: #343131;
+}
+/* line 101, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-invert:hover {
+  background-color: #413d3d !important;
+}
+
+/* line 104, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-link {
+  background-color: transparent !important;
+  color: #2980b9;
+  border-color: transparent;
+}
+/* line 108, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-link:hover {
+  background-color: transparent !important;
+  color: #409ad5;
+  border-color: transparent;
+}
+/* line 112, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.btn-link:active {
+  background-color: transparent !important;
+  border-color: transparent;
+  border-top: solid 1px transparent;
+  border-bottom: solid 3px transparent;
+}
+
+/* line 118, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.wy-btn-group .btn, .wy-control .btn {
+  vertical-align: middle;
+}
+
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_button.sass */
+.wy-btn-group {
+  margin-bottom: 24px;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-btn-group:before, .wy-btn-group:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-btn-group:after {
+  clear: both;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown {
+  position: relative;
+  display: inline-block;
+}
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown:hover .wy-dropdown-menu {
+  display: block;
+}
+/* line 8, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown .caret:after {
+  font-family: fontawesome-webfont;
+  content: "\f0d7";
+  font-size: 70%;
+}
+
+/* line 13, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  display: none;
+  float: left;
+  min-width: 100%;
+  background: #fcfcfc;
+  z-index: 100;
+  border: solid 1px #cfd7dd;
+  box-shadow: 0 5px 5px 0 rgba(0, 0, 0, 0.1);
+  padding: 12px;
+}
+/* line 25, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd > a {
+  display: block;
+  clear: both;
+  color: #404040;
+  white-space: nowrap;
+  font-size: 90%;
+  padding: 0 12px;
+}
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd > a:hover {
+  background: #2980b9;
+  color: white;
+}
+/* line 35, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.divider {
+  border-top: solid 1px #cfd7dd;
+  margin: 6px 0;
+}
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.search {
+  padding-bottom: 12px;
+}
+/* line 40, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.search input[type="search"] {
+  width: 100%;
+}
+/* line 42, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.call-to-action {
+  background: #e3e3e3;
+  text-transform: uppercase;
+  font-weight: 500;
+  font-size: 80%;
+}
+/* line 47, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.call-to-action:hover {
+  background: #e3e3e3;
+}
+/* line 49, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-menu > dd.call-to-action .btn {
+  color: white;
+}
+
+/* line 54, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu {
+  background: #fcfcfc;
+  margin-top: 2px;
+}
+/* line 57, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a {
+  padding: 6px 12px;
+}
+/* line 59, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown.wy-dropdown-bubble .wy-dropdown-menu a:hover {
+  background: #2980b9;
+  color: white;
+}
+
+/* line 63, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown.wy-dropdown-left .wy-dropdown-menu {
+  right: 0;
+  text-align: right;
+}
+
+/* line 68, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-arrow:before {
+  content: " ";
+  border-bottom: 5px solid whitesmoke;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  position: absolute;
+  display: block;
+  top: -4px;
+  left: 50%;
+  margin-left: -3px;
+}
+/* line 78, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_dropdown.sass */
+.wy-dropdown-arrow.wy-dropdown-arrow-left:before {
+  left: 11px;
+}
+
+/* line 8, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-stacked select {
+  display: block;
+}
+
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-aligned input, .wy-form-aligned textarea, .wy-form-aligned select, .wy-form-aligned .wy-help-inline, .wy-form-aligned label {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+  vertical-align: middle;
+}
+
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-aligned .wy-control-group > label {
+  display: inline-block;
+  vertical-align: middle;
+  width: 10em;
+  margin: 0.5em 1em 0 0;
+  float: left;
+}
+/* line 25, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-aligned .wy-control {
+  float: left;
+}
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-aligned .wy-control label {
+  display: block;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-aligned .wy-control select {
+  margin-top: 0.5em;
+}
+
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+fieldset {
+  border: 0;
+  margin: 0;
+  padding: 0;
+}
+
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+legend {
+  display: block;
+  width: 100%;
+  border: 0;
+  padding: 0;
+  white-space: normal;
+  margin-bottom: 24px;
+  font-size: 150%;
+  *margin-left: -7px;
+}
+
+/* line 47, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+label {
+  display: block;
+  margin: 0 0 0.3125em 0;
+  color: #999999;
+  font-size: 90%;
+}
+
+/* line 55, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+button, input, select, textarea {
+  font-size: 100%;
+  margin: 0;
+  vertical-align: baseline;
+  *vertical-align: middle;
+}
+
+/* line 60, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+button, input {
+  line-height: normal;
+}
+
+/* line 62, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+button {
+  -webkit-appearance: button;
+  cursor: pointer;
+  *overflow: visible;
+}
+
+/* line 66, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+button::-moz-focus-inner, input::-moz-focus-inner {
+  border: 0;
+  padding: 0;
+}
+
+/* line 69, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+button[disabled] {
+  cursor: default;
+}
+
+/* line 75, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="button"], input[type="reset"], input[type="submit"] {
+  -webkit-appearance: button;
+  cursor: pointer;
+  *overflow: visible;
+}
+/* line 79, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="text"], input[type="password"], input[type="email"], input[type="url"], input[type="date"], input[type="month"], input[type="time"], input[type="datetime"], input[type="datetime-local"], input[type="week"], input[type="number"], input[type="search"], input[type="tel"], input[type="color"] {
+  -webkit-appearance: none;
+  padding: 6px;
+  display: inline-block;
+  border: 1px solid #cccccc;
+  font-size: 80%;
+  font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+  box-shadow: inset 0 1px 3px #dddddd;
+  border-radius: 0;
+  -webkit-transition: border 0.3s linear;
+  -moz-transition: border 0.3s linear;
+  transition: border 0.3s linear;
+}
+/* line 90, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="datetime-local"] {
+  padding: 0.34375em 0.625em;
+}
+/* line 92, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[disabled] {
+  cursor: default;
+}
+/* line 94, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="checkbox"], input[type="radio"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  padding: 0;
+  margin-right: 0.3125em;
+  *height: 13px;
+  *width: 13px;
+}
+/* line 100, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="search"] {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+/* line 102, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="search"]::-webkit-search-cancel-button, input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+/* line 104, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="text"]:focus, input[type="password"]:focus, input[type="email"]:focus, input[type="url"]:focus, input[type="date"]:focus, input[type="month"]:focus, input[type="time"]:focus, input[type="datetime"]:focus, input[type="datetime-local"]:focus, input[type="week"]:focus, input[type="number"]:focus, input[type="search"]:focus, input[type="tel"]:focus, input[type="color"]:focus {
+  outline: 0;
+  outline: thin dotted \9;
+  border-color: #2980b9;
+}
+/* line 108, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input.no-focus:focus {
+  border-color: #cccccc !important;
+}
+/* line 110, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="file"]:focus, input[type="radio"]:focus, input[type="checkbox"]:focus {
+  outline: thin dotted #333333;
+  outline: 1px auto #129fea;
+}
+/* line 113, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="text"][disabled], input[type="password"][disabled], input[type="email"][disabled], input[type="url"][disabled], input[type="date"][disabled], input[type="month"][disabled], input[type="time"][disabled], input[type="datetime"][disabled], input[type="datetime-local"][disabled], input[type="week"][disabled], input[type="number"][disabled], input[type="search"][disabled], input[type="tel"][disabled], input[type="color"][disabled] {
+  cursor: not-allowed;
+  background-color: #f3f6f6;
+  color: #cad2d3;
+}
+
+/* line 118, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input:focus:invalid, textarea:focus:invalid, select:focus:invalid {
+  color: #e74c3c;
+  border: 1px solid #e74c3c;
+}
+
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input:focus:invalid:focus, textarea:focus:invalid:focus, select:focus:invalid:focus {
+  border-color: #e9322d;
+}
+
+/* line 124, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input[type="file"]:focus:invalid:focus, input[type="radio"]:focus:invalid:focus, input[type="checkbox"]:focus:invalid:focus {
+  outline-color: #e9322d;
+}
+
+/* line 127, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+input.wy-input-large {
+  padding: 12px;
+  font-size: 100%;
+}
+
+/* line 133, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+textarea {
+  overflow: auto;
+  vertical-align: top;
+  width: 100%;
+}
+
+/* line 137, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+select, textarea {
+  padding: 0.5em 0.625em;
+  display: inline-block;
+  border: 1px solid #cccccc;
+  font-size: 0.8em;
+  box-shadow: inset 0 1px 3px #dddddd;
+  -webkit-transition: border 0.3s linear;
+  -moz-transition: border 0.3s linear;
+  transition: border 0.3s linear;
+}
+
+/* line 145, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+select {
+  border: 1px solid #cccccc;
+  background-color: white;
+}
+/* line 148, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+select[multiple] {
+  height: auto;
+}
+
+/* line 150, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+select:focus, textarea:focus {
+  outline: 0;
+}
+
+/* line 152, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+select[disabled], textarea[disabled], input[readonly], select[readonly], textarea[readonly] {
+  cursor: not-allowed;
+  background-color: white;
+  color: #cad2d3;
+  border-color: transparent;
+}
+
+/* line 160, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-checkbox, .wy-radio {
+  margin: 0.5em 0;
+  color: #404040 !important;
+  display: block;
+}
+
+/* line 168, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-message-inline {
+  display: inline-block;
+  *display: inline;
+  *zoom: 1;
+  vertical-align: middle;
+}
+
+/* line 174, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-input-prefix, .wy-input-suffix {
+  white-space: nowrap;
+}
+/* line 176, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-input-prefix .wy-input-context, .wy-input-suffix .wy-input-context {
+  padding: 6px;
+  display: inline-block;
+  font-size: 80%;
+  background-color: #f3f6f6;
+  border: solid 1px #cccccc;
+  color: #999999;
+}
+
+/* line 184, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-input-suffix .wy-input-context {
+  border-left: 0;
+}
+
+/* line 186, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-input-prefix .wy-input-context {
+  border-right: 0;
+}
+
+/* line 189, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate {
+  white-space: nowrap;
+}
+/* line 191, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate .wy-input-context {
+  padding: 0.5em 0.625em;
+  display: inline-block;
+  font-size: 80%;
+}
+
+/* line 195, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate.wy-inline-validate-success .wy-input-context {
+  color: #27ae60;
+}
+
+/* line 199, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate.wy-inline-validate-danger .wy-input-context {
+  color: #e74c3c;
+}
+
+/* line 203, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate.wy-inline-validate-warning .wy-input-context {
+  color: #e67e22;
+}
+
+/* line 207, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-inline-validate.wy-inline-validate-info .wy-input-context {
+  color: #2980b9;
+}
+
+/* line 212, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-control-group {
+  margin-bottom: 24px;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-control-group:before, .wy-control-group:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-control-group:after {
+  clear: both;
+}
+
+/* line 217, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-control-group.wy-control-group-error .wy-form-message, .wy-control-group.wy-control-group-error label {
+  color: #e74c3c;
+}
+/* line 220, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-control-group.wy-control-group-error input[type="text"], .wy-control-group.wy-control-group-error input[type="password"], .wy-control-group.wy-control-group-error input[type="email"], .wy-control-group.wy-control-group-error input[type="url"], .wy-control-group.wy-control-group-error input[type="date"], .wy-control-group.wy-control-group-error input[type="month"], .wy-control-group.wy-control-group-error input[type="time"], .wy-control-group.wy-control-group-error input[type="datetime"], .wy-control-group.wy-control-group-error input[type="datetime-local"], .wy-control-group.wy-control-group-error input[type="week"], .wy-control-group.wy-control-group-error input[type="number"], .wy-control-group.wy-control-group-error input[type="search"], .wy-control-group.wy-control-group-error input[type="tel"], .wy-control-group.wy-control-group-error input[type="color"] {
+  border: solid 2px #e74c3c;
+}
+/* line 222, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-control-group.wy-control-group-error textarea {
+  border: solid 2px #e74c3c;
+}
+
+/* line 229, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-control-group.fluid-input input[type="text"], .wy-control-group.fluid-input input[type="password"], .wy-control-group.fluid-input input[type="email"], .wy-control-group.fluid-input input[type="url"], .wy-control-group.fluid-input input[type="date"], .wy-control-group.fluid-input input[type="month"], .wy-control-group.fluid-input input[type="time"], .wy-control-group.fluid-input input[type="datetime"], .wy-control-group.fluid-input input[type="datetime-local"], .wy-control-group.fluid-input input[type="week"], .wy-control-group.fluid-input input[type="number"], .wy-control-group.fluid-input input[type="search"], .wy-control-group.fluid-input input[type="tel"], .wy-control-group.fluid-input input[type="color"] {
+  width: 100%;
+}
+
+/* line 234, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-message-inline {
+  display: inline-block;
+  padding-left: 0.3em;
+  color: #666666;
+  vertical-align: middle;
+  font-size: 90%;
+}
+
+/* line 241, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-message {
+  display: block;
+  color: #cccccc;
+  font-size: 70%;
+  margin-top: 0.3125em;
+  font-style: italic;
+}
+
+/* line 250, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group {
+  padding: 4px 4px 0px 4px;
+  display: inline-block;
+  border: 1px solid #cccccc;
+  font-size: 80%;
+  font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+  box-shadow: inset 0 1px 3px #dddddd;
+  -webkit-transition: border 0.3s linear;
+  -moz-transition: border 0.3s linear;
+  transition: border 0.3s linear;
+}
+/* line 259, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group .wy-tag {
+  display: inline-block;
+  background-color: rgba(0, 0, 0, 0.1);
+  padding: 0.5em 0.625em;
+  border-radius: 2px;
+  position: relative;
+  margin-bottom: 4px;
+}
+/* line 266, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group .wy-tag .wy-tag-remove {
+  color: #cccccc;
+  margin-left: 5px;
+}
+/* line 271, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group .wy-tag .wy-tag-remove:hover {
+  color: #e74c3c;
+}
+/* line 274, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group label {
+  margin-left: 5px;
+  display: inline-block;
+  margin-bottom: 0;
+}
+/* line 278, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-tag-input-group input {
+  border: none;
+  font-size: 100%;
+  margin-bottom: 4px;
+  box-shadow: none;
+}
+
+/* line 286, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload {
+  border: solid 1px #cccccc;
+  border-bottom: solid 3px #cccccc;
+  background-color: white;
+  padding: 24px;
+  display: inline-block;
+  text-align: center;
+  cursor: pointer;
+  color: #404040;
+  -webkit-transition: border-color 0.1s ease-in;
+  -moz-transition: border-color 0.1s ease-in;
+  transition: border-color 0.1s ease-in;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-form-upload:before, .wy-form-upload:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-form-upload:after {
+  clear: both;
+}
+@media screen and (max-width: 480px) {
+  /* line 286, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-upload {
+    width: 100%;
+  }
+}
+/* line 299, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .image-drop {
+  display: none;
+}
+/* line 301, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .image-desktop {
+  display: none;
+}
+/* line 303, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .image-loading {
+  display: none;
+}
+/* line 305, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .wy-form-upload-icon {
+  display: block;
+  font-size: 32px;
+  color: #b3b3b3;
+}
+/* line 309, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .image-drop .wy-form-upload-icon {
+  color: #27ae60;
+}
+/* line 311, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload p {
+  font-size: 90%;
+}
+/* line 313, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .wy-form-upload-image {
+  float: left;
+  margin-right: 24px;
+}
+@media screen and (max-width: 480px) {
+  /* line 313, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-upload .wy-form-upload-image {
+    width: 100%;
+    margin-bottom: 24px;
+  }
+}
+/* line 319, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload img {
+  max-width: 125px;
+  max-height: 125px;
+  opacity: 0.9;
+  -webkit-transition: opacity 0.1s ease-in;
+  -moz-transition: opacity 0.1s ease-in;
+  transition: opacity 0.1s ease-in;
+}
+/* line 324, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload .wy-form-upload-content {
+  float: left;
+}
+@media screen and (max-width: 480px) {
+  /* line 324, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-upload .wy-form-upload-content {
+    width: 100%;
+  }
+}
+
+/* line 329, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload:hover {
+  border-color: #b3b3b3;
+  color: #404040;
+}
+/* line 332, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload:hover .image-desktop {
+  display: block;
+}
+/* line 334, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload:hover .image-drag {
+  display: none;
+}
+/* line 336, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload:hover img {
+  opacity: 1;
+}
+
+/* line 339, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload:active {
+  border-top: solid 3px #cccccc;
+  border-bottom: solid 1px #cccccc;
+}
+
+/* line 343, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-big {
+  width: 100%;
+  text-align: center;
+  padding: 72px;
+}
+/* line 347, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-big .wy-form-upload-content {
+  float: none;
+}
+
+/* line 351, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-file p {
+  margin-bottom: 0;
+}
+/* line 353, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-file .wy-form-upload-icon {
+  display: inline-block;
+  font-size: inherit;
+}
+
+/* line 357, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-drop {
+  background-color: #ddf7e8;
+}
+/* line 359, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-drop .image-drop {
+  display: block;
+}
+/* line 361, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-drop .image-desktop {
+  display: none;
+}
+/* line 363, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-drop .image-drag {
+  display: none;
+}
+
+/* line 367, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-loading .image-drag {
+  display: none;
+}
+/* line 369, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-loading .image-desktop {
+  display: none;
+}
+/* line 371, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-loading .image-loading {
+  display: block;
+}
+/* line 373, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-loading .wy-input-prefix {
+  display: none;
+}
+/* line 375, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-upload.wy-form-upload-loading p {
+  margin-bottom: 0;
+}
+
+/* line 380, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.rotate-90 {
+  -webkit-transform: rotate(90deg);
+  -moz-transform: rotate(90deg);
+  -ms-transform: rotate(90deg);
+  -o-transform: rotate(90deg);
+  transform: rotate(90deg);
+}
+
+/* line 382, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.rotate-180 {
+  -webkit-transform: rotate(180deg);
+  -moz-transform: rotate(180deg);
+  -ms-transform: rotate(180deg);
+  -o-transform: rotate(180deg);
+  transform: rotate(180deg);
+}
+
+/* line 384, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.rotate-270 {
+  -webkit-transform: rotate(270deg);
+  -moz-transform: rotate(270deg);
+  -ms-transform: rotate(270deg);
+  -o-transform: rotate(270deg);
+  transform: rotate(270deg);
+}
+
+/* line 386, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.mirror {
+  -webkit-transform: scaleX(-1);
+  -moz-transform: scaleX(-1);
+  -ms-transform: scaleX(-1);
+  -o-transform: scaleX(-1);
+  transform: scaleX(-1);
+}
+/* line 388, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.mirror.rotate-90 {
+  -webkit-transform: scaleX(-1) rotate(90deg);
+  -moz-transform: scaleX(-1) rotate(90deg);
+  -ms-transform: scaleX(-1) rotate(90deg);
+  -o-transform: scaleX(-1) rotate(90deg);
+  transform: scaleX(-1) rotate(90deg);
+}
+/* line 390, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.mirror.rotate-180 {
+  -webkit-transform: scaleX(-1) rotate(180deg);
+  -moz-transform: scaleX(-1) rotate(180deg);
+  -ms-transform: scaleX(-1) rotate(180deg);
+  -o-transform: scaleX(-1) rotate(180deg);
+  transform: scaleX(-1) rotate(180deg);
+}
+/* line 392, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.mirror.rotate-270 {
+  -webkit-transform: scaleX(-1) rotate(270deg);
+  -moz-transform: scaleX(-1) rotate(270deg);
+  -ms-transform: scaleX(-1) rotate(270deg);
+  -o-transform: scaleX(-1) rotate(270deg);
+  transform: scaleX(-1) rotate(270deg);
+}
+
+/* line 397, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage {
+  margin-left: -12px;
+  margin-right: -12px;
+}
+/* line 400, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage li {
+  float: left;
+  padding: 12px;
+  width: 20%;
+  cursor: pointer;
+}
+@media screen and (max-width: 768px) {
+  /* line 400, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-gallery-manage li {
+    width: 25%;
+  }
+}
+@media screen and (max-width: 480px) {
+  /* line 400, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-gallery-manage li {
+    width: 50%;
+  }
+}
+/* line 409, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage li:active {
+  cursor: move;
+}
+/* line 411, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage li > a {
+  padding: 12px;
+  background-color: white;
+  border: solid 1px #e1e4e5;
+  border-bottom: solid 3px #e1e4e5;
+  display: inline-block;
+  -webkit-transition: all 0.1s ease-in;
+  -moz-transition: all 0.1s ease-in;
+  transition: all 0.1s ease-in;
+}
+/* line 418, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage li > a:active {
+  border: solid 1px #cccccc;
+  border-top: solid 3px #cccccc;
+}
+/* line 421, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+.wy-form-gallery-manage img {
+  width: 100%;
+  -webkit-transition: all 0.05s ease-in;
+  -moz-transition: all 0.05s ease-in;
+  transition: all 0.05s ease-in;
+}
+
+/* line 425, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+li.wy-form-gallery-edit {
+  position: relative;
+  color: white;
+  padding: 24px;
+  width: 100%;
+  display: block;
+  background-color: #343131;
+  border-radius: 4px;
+}
+/* line 433, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+li.wy-form-gallery-edit .arrow {
+  position: absolute;
+  display: block;
+  top: -50px;
+  left: 50%;
+  margin-left: -25px;
+  z-index: 500;
+  height: 0;
+  width: 0;
+  border-color: transparent;
+  border-style: solid;
+  border-width: 25px;
+  border-bottom-color: #343131;
+}
+
+@media only screen and (max-width: 480px) {
+  /* line 444, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form button[type="submit"] {
+    margin: 0.7em 0 0;
+  }
+  /* line 447, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form input[type="text"], .wy-form input[type="password"], .wy-form input[type="email"], .wy-form input[type="url"], .wy-form input[type="date"], .wy-form input[type="month"], .wy-form input[type="time"], .wy-form input[type="datetime"], .wy-form input[type="datetime-local"], .wy-form input[type="week"], .wy-form input[type="number"], .wy-form input[type="search"], .wy-form input[type="tel"], .wy-form input[type="color"] {
+    margin-bottom: 0.3em;
+    display: block;
+  }
+  /* line 450, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form label {
+    margin-bottom: 0.3em;
+    display: block;
+  }
+
+  /* line 454, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form input[type="password"], .wy-form input[type="email"], .wy-form input[type="url"], .wy-form input[type="date"], .wy-form input[type="month"], .wy-form input[type="time"], .wy-form input[type="datetime"], .wy-form input[type="datetime-local"], .wy-form input[type="week"], .wy-form input[type="number"], .wy-form input[type="search"], .wy-form input[type="tel"], .wy-form input[type="color"] {
+    margin-bottom: 0;
+  }
+
+  /* line 457, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-aligned .wy-control-group label {
+    margin-bottom: 0.3em;
+    text-align: left;
+    display: block;
+    width: 100%;
+  }
+  /* line 462, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form-aligned .wy-controls {
+    margin: 1.5em 0 0 0;
+  }
+
+  /* NOTE: wy-help-inline is deprecated. Use .wy-form-message-inline instead. */
+  /* line 465, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_form.sass */
+  .wy-form .wy-help-inline, .wy-form-message-inline, .wy-form-message {
+    display: block;
+    font-size: 80%;
+    /* Increased bottom padding to make it group with its related input element. */
+    padding: 0.2em 0 0.8em;
+  }
+}
+@media screen and (max-width: 768px) {
+  /* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_generic.sass */
+  .tablet-hide {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 480px) {
+  /* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_generic.sass */
+  .mobile-hide {
+    display: none;
+  }
+}
+
+/* line 9, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_generic.sass */
+.float-left {
+  float: left;
+}
+
+/* line 12, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_generic.sass */
+.float-right {
+  float: right;
+}
+
+/* line 15, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_generic.sass */
+.full-width {
+  width: 100%;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-one-col {
+  *zoom: 1;
+  max-width: 68em;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1066px;
+  margin-top: 1.618em;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-one-col:before, .wy-grid-one-col:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-one-col:after {
+  clear: both;
+}
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-one-col section {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 100%;
+  background: #fcfcfc;
+  padding: 1.618em;
+  margin-right: 0;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-one-col section:last-child {
+  margin-right: 0;
+}
+
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-index-card {
+  *zoom: 1;
+  max-width: 68em;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 460px;
+  margin-top: 1.618em;
+  background: #fcfcfc;
+  padding: 1.618em;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-index-card:before, .wy-grid-index-card:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-index-card:after {
+  clear: both;
+}
+/* line 17, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-index-card header, .wy-grid-index-card section, .wy-grid-index-card aside {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 100%;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-index-card header:last-child, .wy-grid-index-card section:last-child, .wy-grid-index-card aside:last-child {
+  margin-right: 0;
+}
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-index-card.twocol {
+  max-width: 768px;
+}
+/* line 21, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-index-card.twocol section {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 48.82117%;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-index-card.twocol section:last-child {
+  margin-right: 0;
+}
+/* line 23, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-index-card.twocol aside {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 48.82117%;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-index-card.twocol aside:last-child {
+  margin-right: 0;
+}
+
+/* line 26, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-search-filter {
+  *zoom: 1;
+  max-width: 68em;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 24px;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-search-filter:before, .wy-grid-search-filter:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-grid-search-filter:after {
+  clear: both;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-search-filter .wy-grid-search-filter-input {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 74.41059%;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-search-filter .wy-grid-search-filter-input:last-child {
+  margin-right: 0;
+}
+/* line 31, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_grid_layout.sass */
+.wy-grid-search-filter .wy-grid-search-filter-btn {
+  display: block;
+  float: left;
+  margin-right: 2.35765%;
+  width: 23.23176%;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/neat/app/assets/stylesheets/grid/_span-columns.scss */
+.wy-grid-search-filter .wy-grid-search-filter-btn:last-child {
+  margin-right: 0;
+}
+
+/* line 3, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table, .rst-content table.docutils, .rst-content table.docutils.field-list {
+  /* Remove spacing between table cells (from Normalize.css) */
+  border-collapse: collapse;
+  border-spacing: 0;
+  empty-cells: show;
+  margin-bottom: 24px;
+}
+/* line 9, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table caption, .rst-content table.docutils caption, .rst-content table.docutils.field-list caption {
+  color: black;
+  font: italic 85%/1 arial, sans-serif;
+  padding: 1em 0;
+  text-align: center;
+}
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table td, .rst-content table.docutils td, .rst-content table.docutils.field-list td, .wy-table th, .rst-content table.docutils th, .rst-content table.docutils.field-list th {
+  font-size: 90%;
+  margin: 0;
+  overflow: visible;
+  padding: 8px 16px;
+}
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table td:first-child, .rst-content table.docutils td:first-child, .wy-table th:first-child, .rst-content table.docutils th:first-child {
+  border-left-width: 0;
+}
+/* line 21, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table thead, .rst-content table.docutils thead, .rst-content table.docutils.field-list thead {
+  color: black;
+  text-align: left;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+/* line 26, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table thead th, .rst-content table.docutils thead th, .rst-content table.docutils.field-list thead th {
+  font-weight: bold;
+  border-bottom: solid 2px #e1e4e5;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table td, .rst-content table.docutils td, .rst-content table.docutils.field-list td {
+  background-color: transparent;
+  vertical-align: middle;
+}
+
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table td p, .rst-content table.docutils td p, .rst-content table.docutils.field-list td p {
+  line-height: 18px;
+  margin-bottom: 0;
+}
+
+/* line 37, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table .wy-table-cell-min, .rst-content table.docutils .wy-table-cell-min {
+  width: 1%;
+  padding-right: 0;
+}
+/* line 40, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table .wy-table-cell-min input[type=checkbox], .rst-content table.docutils .wy-table-cell-min input[type=checkbox], .wy-table .wy-table-cell-min input[type=checkbox], .rst-content table.docutils .wy-table-cell-min input[type=checkbox] {
+  margin: 0;
+}
+
+/* line 43, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-secondary {
+  color: gray;
+  font-size: 90%;
+}
+
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-tertiary {
+  color: gray;
+  font-size: 80%;
+}
+
+/*striping:
+ *   even - #fff (white)
+ *   odd  - #f2f2f2 (light gray) */
+/* line 55, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-odd td, .wy-table-striped tr:nth-child(2n-1) td, .rst-content table.docutils:not(.field-list) tr:nth-child(2n-1) td {
+  background-color: #f3f6f6;
+}
+
+/* line 58, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-backed {
+  background-color: #f3f6f6;
+}
+
+/* nth-child selector for modern browsers */
+/* BORDERED TABLES */
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered-all, .rst-content table.docutils {
+  border: 1px solid #e1e4e5;
+}
+/* line 67, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered-all td, .rst-content table.docutils td {
+  border-bottom: 1px solid #e1e4e5;
+  border-left: 1px solid #e1e4e5;
+}
+/* line 70, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered-all tbody > tr:last-child td, .rst-content table.docutils tbody > tr:last-child td {
+  border-bottom-width: 0;
+}
+
+/* line 73, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered {
+  border: 1px solid #e1e4e5;
+}
+
+/* line 77, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered-rows td {
+  border-bottom: 1px solid #e1e4e5;
+}
+/* line 79, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-bordered-rows tbody > tr:last-child td {
+  border-bottom-width: 0;
+}
+
+/* line 83, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-horizontal tbody > tr:last-child td {
+  border-bottom-width: 0;
+}
+/* line 85, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-horizontal td, .wy-table-horizontal th {
+  border-width: 0 0 1px 0;
+  border-bottom: 1px solid #e1e4e5;
+}
+/* line 88, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-horizontal tbody > tr:last-child td {
+  border-bottom-width: 0;
+}
+
+/* RESPONSIVE TABLES */
+/* line 92, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-responsive {
+  margin-bottom: 24px;
+  max-width: 100%;
+  overflow: auto;
+}
+/* line 96, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-responsive table {
+  margin-bottom: 0 !important;
+}
+/* line 98, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_table.sass */
+.wy-table-responsive table td, .wy-table-responsive table th {
+  white-space: nowrap;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+html {
+  height: 100%;
+  overflow-x: hidden;
+}
+
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+body {
+  font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+  font-weight: normal;
+  color: #404040;
+  min-height: 100%;
+  overflow-x: hidden;
+  background: #edf0f2;
+}
+
+/* line 13, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a {
+  color: #2980b9;
+  text-decoration: none;
+}
+/* line 16, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a:hover {
+  color: #3091d1;
+}
+
+/* line 19, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.link-danger {
+  color: #e74c3c;
+}
+/* line 21, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.link-danger:hover {
+  color: #d62c1a;
+}
+
+/* line 24, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.text-left {
+  text-align: left;
+}
+
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.text-center {
+  text-align: center;
+}
+
+/* line 30, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.text-right {
+  text-align: right;
+}
+
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h1, h2, h3, h4, h5, h6, legend {
+  margin-top: 0;
+  font-weight: 700;
+  font-family: "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, sans-serif;
+}
+
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+p {
+  line-height: 24px;
+  margin: 0;
+  font-size: 16px;
+  margin-bottom: 24px;
+}
+
+/* line 44, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h1 {
+  font-size: 175%;
+}
+
+/* line 47, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h2 {
+  font-size: 150%;
+}
+
+/* line 50, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h3 {
+  font-size: 125%;
+}
+
+/* line 53, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h4 {
+  font-size: 115%;
+}
+
+/* line 56, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h5 {
+  font-size: 110%;
+}
+
+/* line 59, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+h6 {
+  font-size: 100%;
+}
+
+/* line 62, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+small {
+  font-size: 80%;
+}
+
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+code {
+  white-space: nowrap;
+  max-width: 100%;
+  background: white;
+  border: solid 1px #e1e4e5;
+  font-size: 80%;
+  padding: 0 5px;
+  font-family: "Incosolata", "Consolata", "Monaco", monospace;
+  color: #e74c3c;
+  overflow-x: auto;
+}
+/* line 75, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+code.code-large {
+  font-size: 90%;
+}
+
+/* line 78, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.full-width {
+  width: 100%;
+}
+
+/* line 81, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-disc, .rst-content .section ul, .rst-content ul.simple, .rst-content ul.stimple ul, .rst-content .toctree-wrapper ul {
+  list-style: disc;
+  line-height: 24px;
+  margin-bottom: 24px;
+}
+
+/* line 85, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-disc li, .rst-content .section ul li, .rst-content ul.simple li, .rst-content ul.stimple ul li, .rst-content .toctree-wrapper ul li {
+  list-style: disc;
+  margin-left: 24px;
+}
+/* line 88, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-disc li ul, .rst-content .section ul li ul, .rst-content ul.simple li ul, .rst-content ul.stimple ul li ul, .rst-content .toctree-wrapper ul li ul {
+  margin-bottom: 0;
+}
+/* line 90, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-disc li li, .rst-content .section ul li li, .rst-content ul.simple li li, .rst-content ul.stimple ul li li, .rst-content .toctree-wrapper ul li li {
+  list-style: circle;
+}
+/* line 92, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-disc li li li, .rst-content .section ul li li li, .rst-content ul.simple li li li, .rst-content ul.stimple ul li li li, .rst-content .toctree-wrapper ul li li li {
+  list-style: square;
+}
+
+/* line 95, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-decimal, .rst-content .section ol, .rst-content ol.simple, .rst-content ol.arabic {
+  list-style: decimal;
+  line-height: 24px;
+  margin-bottom: 24px;
+}
+
+/* line 99, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-plain-list-decimal li, .rst-content .section ol li, .rst-content ol.simple li, .rst-content ol.arabic li {
+  list-style: decimal;
+  margin-left: 24px;
+}
+
+/* line 103, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-type-large {
+  font-size: 120%;
+}
+
+/* line 106, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-type-normal {
+  font-size: 100%;
+}
+
+/* line 109, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-type-small {
+  font-size: 100%;
+}
+
+/* line 112, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-type-strike {
+  text-decoration: line-through;
+}
+
+/* line 115, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-text-warning {
+  color: #e67e22 !important;
+}
+
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a.wy-text-warning:hover {
+  color: #eb9950 !important;
+}
+
+/* line 119, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-text-info {
+  color: #2980b9 !important;
+}
+
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a.wy-text-info:hover {
+  color: #409ad5 !important;
+}
+
+/* line 123, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-text-success {
+  color: #27ae60 !important;
+}
+
+/* line 125, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a.wy-text-success:hover {
+  color: #36d278 !important;
+}
+
+/* line 127, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-text-danger {
+  color: #e74c3c !important;
+}
+
+/* line 129, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a.wy-text-danger:hover {
+  color: #ed7669 !important;
+}
+
+/* line 131, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+.wy-text-neutral {
+  color: #404040 !important;
+}
+
+/* line 133, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_type.sass */
+a.wy-text-neutral:hover {
+  color: #595959 !important;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.codeblock-example {
+  border: 1px solid #e1e4e5;
+  border-bottom: none;
+  padding: 24px;
+  padding-top: 48px;
+  font-weight: 500;
+  background: white;
+  position: relative;
+}
+/* line 9, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.codeblock-example:after {
+  content: "Example";
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background: #9b59b6;
+  color: white;
+  padding: 6px 12px;
+}
+/* line 17, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.codeblock-example.prettyprint-example-only {
+  border: 1px solid #e1e4e5;
+  margin-bottom: 24px;
+}
+
+/* line 21, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.codeblock, div[class^='highlight'] {
+  border: 1px solid #e1e4e5;
+  padding: 0px;
+  width: 100%;
+  overflow-x: auto;
+  background: white;
+  margin: 1px 0 24px 0;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.codeblock div[class^='highlight'], div[class^='highlight'] div[class^='highlight'] {
+  border: none;
+  background: none;
+  margin: 0;
+}
+
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+.linenodiv pre {
+  border-right: solid 1px #e6e9ea;
+  margin: 0;
+  padding: 12px 12px;
+  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, "source-code-pro-1", "source-code-pro-2", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: #d9d9d9;
+}
+
+/* line 42, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+div[class^='highlight'] pre {
+  white-space: pre;
+  margin: 0;
+  padding: 12px 12px;
+  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, "source-code-pro-1", "source-code-pro-2", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  display: block;
+  overflow: auto;
+  color: #404040;
+}
+
+/* line 52, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+pre.literal-block {
+  @extends .codeblock;
+  background: #343131;
+  color: white;
+  padding: 42px 12px 12px 12px;
+  font-family: Menlo, "Bitstream Vera Sans Mono", "DejaVu Sans Mono", Monaco, Consolas, "source-code-pro-1", "source-code-pro-2", monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  position: relative;
+}
+/* line 61, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+pre.literal-block:after {
+  position: absolute;
+  content: "  Terminal";
+  background: #f3f6f6;
+  color: #404040;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 6px 0;
+}
+
+@media print {
+  /* line 72, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments.sass */
+  .codeblock, div[class^='highlight'], div[class^='highlight'] pre {
+    white-space: pre-wrap;
+  }
+}
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.hll {
+  background-color: #f8f8f8;
+  border: 1px solid #cccccc;
+  padding: 1.5px 5px;
+}
+
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.c {
+  color: #999988;
+  font-style: italic;
+}
+
+/* line 8, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.err {
+  color: #a61717;
+  background-color: #e3d2d2;
+}
+
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.k {
+  font-weight: bold;
+}
+
+/* line 13, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.o {
+  font-weight: bold;
+}
+
+/* line 15, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.cm {
+  color: #999988;
+  font-style: italic;
+}
+
+/* line 18, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.cp {
+  color: #999999;
+  font-weight: bold;
+}
+
+/* line 21, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.c1 {
+  color: #999988;
+  font-style: italic;
+}
+
+/* line 24, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.cs {
+  color: #999999;
+  font-weight: bold;
+  font-style: italic;
+}
+
+/* line 28, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gd {
+  color: black;
+  background-color: #ffdddd;
+}
+
+/* line 31, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gd .x {
+  color: black;
+  background-color: #ffaaaa;
+}
+
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.ge {
+  font-style: italic;
+}
+
+/* line 36, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gr {
+  color: #aa0000;
+}
+
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gh {
+  color: #999999;
+}
+
+/* line 40, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gi {
+  color: black;
+  background-color: #ddffdd;
+}
+
+/* line 43, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gi .x {
+  color: black;
+  background-color: #aaffaa;
+}
+
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.go {
+  color: #888888;
+}
+
+/* line 48, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gp {
+  color: #555555;
+}
+
+/* line 50, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gs {
+  font-weight: bold;
+}
+
+/* line 52, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gu {
+  color: purple;
+  font-weight: bold;
+}
+
+/* line 55, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gt {
+  color: #aa0000;
+}
+
+/* line 57, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kc {
+  font-weight: bold;
+}
+
+/* line 59, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kd {
+  font-weight: bold;
+}
+
+/* line 61, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kn {
+  font-weight: bold;
+}
+
+/* line 63, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kp {
+  font-weight: bold;
+}
+
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kr {
+  font-weight: bold;
+}
+
+/* line 67, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.kt {
+  color: #445588;
+  font-weight: bold;
+}
+
+/* line 70, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.m {
+  color: #009999;
+}
+
+/* line 72, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.s {
+  color: #dd1144;
+}
+
+/* line 74, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.n {
+  color: #333333;
+}
+
+/* line 76, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.na {
+  color: teal;
+}
+
+/* line 78, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nb {
+  color: #0086b3;
+}
+
+/* line 80, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nc {
+  color: #445588;
+  font-weight: bold;
+}
+
+/* line 83, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.no {
+  color: teal;
+}
+
+/* line 85, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.ni {
+  color: purple;
+}
+
+/* line 87, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.ne {
+  color: #990000;
+  font-weight: bold;
+}
+
+/* line 90, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nf {
+  color: #990000;
+  font-weight: bold;
+}
+
+/* line 93, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nn {
+  color: #555555;
+}
+
+/* line 95, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nt {
+  color: navy;
+}
+
+/* line 97, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.nv {
+  color: teal;
+}
+
+/* line 99, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.ow {
+  font-weight: bold;
+}
+
+/* line 101, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.w {
+  color: #bbbbbb;
+}
+
+/* line 103, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.mf {
+  color: #009999;
+}
+
+/* line 105, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.mh {
+  color: #009999;
+}
+
+/* line 107, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.mi {
+  color: #009999;
+}
+
+/* line 109, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.mo {
+  color: #009999;
+}
+
+/* line 111, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sb {
+  color: #dd1144;
+}
+
+/* line 113, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sc {
+  color: #dd1144;
+}
+
+/* line 115, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sd {
+  color: #dd1144;
+}
+
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.s2 {
+  color: #dd1144;
+}
+
+/* line 119, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.se {
+  color: #dd1144;
+}
+
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sh {
+  color: #dd1144;
+}
+
+/* line 123, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.si {
+  color: #dd1144;
+}
+
+/* line 125, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sx {
+  color: #dd1144;
+}
+
+/* line 127, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.sr {
+  color: #009926;
+}
+
+/* line 129, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.s1 {
+  color: #dd1144;
+}
+
+/* line 131, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.ss {
+  color: #990073;
+}
+
+/* line 133, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.bp {
+  color: #999999;
+}
+
+/* line 135, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.vc {
+  color: teal;
+}
+
+/* line 137, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.vg {
+  color: teal;
+}
+
+/* line 139, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.vi {
+  color: teal;
+}
+
+/* line 141, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.il {
+  color: #009999;
+}
+
+/* line 143, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_addons/pygments/_pygments_light.sass */
+.gc {
+  color: #999999;
+  background-color: #eaf2f5;
+}
+
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+.wy-breadcrumbs li {
+  display: inline-block;
+}
+/* line 3, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+.wy-breadcrumbs li.wy-breadcrumbs-aside {
+  float: right;
+}
+/* line 5, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+.wy-breadcrumbs li a {
+  display: inline-block;
+  padding: 5px;
+}
+/* line 8, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+.wy-breadcrumbs li a:first-child {
+  padding-left: 0;
+}
+
+/* line 10, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+.wy-breadcrumbs-extra {
+  margin-bottom: 0;
+  color: #b3b3b3;
+  font-size: 80%;
+  display: inline-block;
+}
+
+@media screen and (max-width: 480px) {
+  /* line 18, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+  .wy-breadcrumbs-extra {
+    display: none;
+  }
+
+  /* line 20, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+  .wy-breadcrumbs li.wy-breadcrumbs-aside {
+    display: none;
+  }
+}
+@media print {
+  /* line 24, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_breadcrumbs.sass */
+  .wy-breadcrumbs li.wy-breadcrumbs-aside {
+    display: none;
+  }
+}
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-affix {
+  position: fixed;
+  top: 1.618em;
+}
+
+/* line 6, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu a:hover {
+  text-decoration: none;
+}
+
+/* line 9, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz {
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-menu-horiz:before, .wy-menu-horiz:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-menu-horiz:after {
+  clear: both;
+}
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz ul, .wy-menu-horiz li {
+  display: inline-block;
+}
+/* line 13, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz li:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+/* line 16, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz li.divide-left {
+  border-left: solid 1px #404040;
+}
+/* line 18, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz li.divide-right {
+  border-right: solid 1px #404040;
+}
+/* line 20, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-horiz a {
+  height: 32px;
+  display: inline-block;
+  line-height: 32px;
+  padding: 0 16px;
+}
+
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical header {
+  height: 32px;
+  display: inline-block;
+  line-height: 32px;
+  padding: 0 1.618em;
+  display: block;
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 80%;
+  color: #2980b9;
+  white-space: nowrap;
+}
+/* line 39, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical ul {
+  margin-bottom: 0;
+}
+/* line 42, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.divide-top {
+  border-top: solid 1px #404040;
+}
+/* line 44, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.divide-bottom {
+  border-bottom: solid 1px #404040;
+}
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.current {
+  background: #e3e3e3;
+}
+/* line 48, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.current a {
+  color: gray;
+  border-right: solid 1px #c9c9c9;
+  padding: 0.4045em 2.427em;
+}
+/* line 52, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.current a:hover {
+  background: #d6d6d6;
+}
+/* line 54, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.current a .current {
+  background: #c9c9c9;
+}
+/* line 56, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.on a, .wy-menu-vertical li.current > a {
+  color: #404040;
+  padding: 0.4045em 1.618em;
+  font-weight: bold;
+  position: relative;
+  background: #fcfcfc;
+  border: none;
+  border-bottom: solid 1px #c9c9c9;
+  padding-left: 1.618em -4px;
+}
+/* line 66, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.on a:hover, .wy-menu-vertical li.current > a:hover {
+  background: #fcfcfc;
+}
+/* line 68, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li.current ul {
+  display: block;
+}
+/* line 70, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li ul {
+  margin-bottom: 0;
+  display: none;
+}
+/* line 73, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical li ul li a {
+  margin-bottom: 0;
+  color: #b3b3b3;
+  font-weight: normal;
+}
+/* line 77, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical a {
+  display: inline-block;
+  line-height: 18px;
+  padding: 0.4045em 1.618em;
+  display: block;
+  position: relative;
+  font-size: 90%;
+  color: #b3b3b3;
+}
+/* line 85, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical a:hover {
+  background-color: #4e4a4a;
+  cursor: pointer;
+}
+/* line 88, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-menu-vertical a:active {
+  background-color: #2980b9;
+  cursor: pointer;
+  color: white;
+}
+
+/* line 93, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-side-nav-search {
+  z-index: 200;
+  background-color: #2980b9;
+  text-align: center;
+  padding: 0.809em;
+  display: block;
+  color: #fcfcfc;
+  margin-bottom: 0.809em;
+}
+/* line 101, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-side-nav-search input[type=text] {
+  width: 100%;
+  border-radius: 50px;
+  padding: 6px 12px;
+  border-color: #2472a4;
+}
+/* line 106, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-side-nav-search img {
+  display: block;
+  margin: auto auto 0.809em auto;
+  height: 45px;
+  width: 45px;
+  background-color: #2980b9;
+  padding: 5px;
+  border-radius: 100%;
+}
+/* line 114, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-side-nav-search > a, .wy-side-nav-search .wy-dropdown > a {
+  color: #fcfcfc;
+  font-size: 100%;
+  font-weight: bold;
+  display: inline-block;
+  padding: 4px 6px;
+  margin-bottom: 0.809em;
+}
+/* line 122, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-side-nav-search > a:hover, .wy-side-nav-search .wy-dropdown > a:hover {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+/* line 126, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav .wy-menu-vertical header {
+  color: #2980b9;
+}
+/* line 128, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav .wy-menu-vertical a {
+  color: #b3b3b3;
+}
+/* line 130, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav .wy-menu-vertical a:hover {
+  background-color: #2980b9;
+  color: white;
+}
+
+/* line 134, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+[data-menu-wrap] {
+  -webkit-transition: all 0.2s ease-in;
+  -moz-transition: all 0.2s ease-in;
+  transition: all 0.2s ease-in;
+  position: absolute;
+  opacity: 1;
+  width: 100%;
+  opacity: 0;
+}
+/* line 140, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+[data-menu-wrap].move-center {
+  left: 0;
+  right: auto;
+  opacity: 1;
+}
+/* line 144, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+[data-menu-wrap].move-left {
+  right: auto;
+  left: -100%;
+  opacity: 0;
+}
+/* line 148, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+[data-menu-wrap].move-right {
+  right: -100%;
+  left: auto;
+  opacity: 0;
+}
+
+/* line 154, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-body-for-nav {
+  background: left repeat-y #fcfcfc;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyRpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMy1jMDExIDY2LjE0NTY2MSwgMjAxMi8wMi8wNi0xNDo1NjoyNyAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNiAoTWFjaW50b3NoKSIgeG1wTU06SW5zdGFuY2VJRD0ieG1wLmlpZDoxOERBMTRGRDBFMUUxMUUzODUwMkJCOThDMEVFNURFMCIgeG1wTU06RG9jdW1lbnRJRD0ieG1wLmRpZDoxOERBMTRGRTBFMUUxMUUzODUwMkJCOThDMEVFNURFMCI+IDx4bXBNTTpEZXJpdmVkRnJvbSBzdFJlZjppbnN0YW5jZUlEPSJ4bXAuaWlkOjE4REExNEZCMEUxRTExRTM4NTAyQkI5OEMwRUU1REUwIiBzdFJlZjpkb2N1bWVudElEPSJ4bXAuZGlkOjE4REExNEZDMEUxRTExRTM4NTAyQkI5OEMwRUU1REUwIi8+IDwvcmRmOkRlc2NyaXB0aW9uPiA8L3JkZjpSREY+IDwveDp4bXBtZXRhPiA8P3hwYWNrZXQgZW5kPSJyIj8+EwrlwAAAAA5JREFUeNpiMDU0BAgwAAE2AJgB9BnaAAAAAElFTkSuQmCC);
+  background-size: 300px 1px;
+}
+
+/* line 159, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-grid-for-nav {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+}
+
+/* line 164, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-side {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 300px;
+  overflow: hidden;
+  min-height: 100%;
+  background: #343131;
+  z-index: 200;
+}
+
+/* line 174, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-top {
+  display: none;
+  background: #2980b9;
+  color: white;
+  padding: 0.4045em 0.809em;
+  position: relative;
+  line-height: 50px;
+  text-align: center;
+  font-size: 100%;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-nav-top:before, .wy-nav-top:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.wy-nav-top:after {
+  clear: both;
+}
+/* line 184, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-top a {
+  color: white;
+  font-weight: bold;
+}
+/* line 188, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-top img {
+  margin-right: 12px;
+  height: 45px;
+  width: 45px;
+  background-color: #2980b9;
+  padding: 5px;
+  border-radius: 100%;
+}
+/* line 195, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-top i {
+  font-size: 30px;
+  float: left;
+  cursor: pointer;
+}
+
+/* line 200, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-content-wrap {
+  margin-left: 300px;
+  background: #fcfcfc;
+  min-height: 100%;
+}
+
+/* line 205, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-nav-content {
+  padding: 1.618em 3.236em;
+  height: 100%;
+  max-width: 800px;
+  margin: auto;
+}
+
+/* line 211, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-body-mask {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.2);
+  display: none;
+  z-index: 499;
+}
+/* line 218, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.wy-body-mask.on {
+  display: block;
+}
+
+/* line 220, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+footer {
+  color: #999999;
+}
+/* line 222, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+footer p {
+  margin-bottom: 12px;
+}
+
+/* line 224, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+.rst-footer-buttons {
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-footer-buttons:before, .rst-footer-buttons:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-footer-buttons:after {
+  clear: both;
+}
+
+@media screen and (max-width: 768px) {
+  /* line 227, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-body-for-nav {
+    background: #fcfcfc;
+  }
+
+  /* line 229, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-top {
+    display: block;
+  }
+
+  /* line 231, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-side {
+    left: -300px;
+  }
+  /* line 236, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-side.shift {
+    width: 85%;
+    left: 0;
+  }
+
+  /* line 239, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content-wrap {
+    margin-left: 0;
+  }
+  /* line 241, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content-wrap .wy-nav-content {
+    padding: 1.618em;
+  }
+  /* line 243, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content-wrap.shift {
+    position: fixed;
+    min-width: 100%;
+    left: 85%;
+    top: 0;
+    height: 100%;
+    overflow: hidden;
+  }
+}
+@media screen and (min-width: 1400px) {
+  /* line 252, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content-wrap {
+    background: rgba(0, 0, 0, 0.05);
+  }
+
+  /* line 254, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content {
+    margin: 0;
+    background: #fcfcfc;
+  }
+}
+@media print {
+  /* line 259, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-side {
+    display: none;
+  }
+
+  /* line 261, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_layout.sass */
+  .wy-nav-content-wrap {
+    margin-left: 0;
+  }
+}
+/* line 1, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 300px;
+  color: #fcfcfc;
+  background: #1f1d1d;
+  border-top: solid 10px #343131;
+  font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
+  z-index: 400;
+}
+/* line 11, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions a {
+  color: #2980b9;
+  text-decoration: none;
+}
+/* line 14, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-badge-small {
+  display: none;
+}
+/* line 16, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version {
+  padding: 12px;
+  background-color: #272525;
+  display: block;
+  text-align: right;
+  font-size: 90%;
+  cursor: pointer;
+  color: #27ae60;
+  *zoom: 1;
+}
+/* line 117, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-versions .rst-current-version:before, .rst-versions .rst-current-version:after {
+  display: table;
+  content: "";
+}
+/* line 121, /home/tony/workspace/sphinx_rtd_theme/bower_components/wyrm/sass/wyrm_core/_mixin.sass */
+.rst-versions .rst-current-version:after {
+  clear: both;
+}
+/* line 25, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version .icon, .rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-success .wy-input-context, .wy-inline-validate.wy-inline-validate-success .rst-versions .rst-current-version .wy-input-context, .rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-danger .wy-input-context, .wy-inline-validate.wy-inline-validate-danger .rst-versions .rst-current-version .wy-input-context, .rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-warning .wy-input-context, .wy-inline-validate.wy-inline-validate-warning .rst-versions .rst-current-version .wy-input-context, .rst-versions .rst-current-version .wy-inline-validate.wy-inline-validate-info .wy-input-context, .wy-inline-validate.wy-inline-validate-info .rst-versions .rst-current-version .wy-input-context, .rst-versions .rst-current-version .wy-tag-input-group .wy-tag .wy-tag-remove, .wy-tag-input-group .wy-tag .rst-versions .rst-current-version .wy-tag-remove, .rst-versions .rst-current-version .rst-content .admonition-title, .rst-content .rst-versions .rst-current-version .admonition-title, .rst-versions .rst-current-version .rst-content h1 .headerlink, .rst-content h1 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h2 .headerlink, .rst-content h2 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h3 .headerlink, .rst-content h3 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h4 .headerlink, .rst-content h4 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h5 .headerlink, .rst-content h5 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content h6 .headerlink, .rst-content h6 .rst-versions .rst-current-version .headerlink, .rst-versions .rst-current-version .rst-content dl dt .headerlink, .rst-content dl dt .rst-versions .rst-current-version .headerlink {
+  color: #fcfcfc;
+}
+/* line 27, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version .icon-book {
+  float: left;
+}
+/* line 29, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-current-version.rst-out-of-date {
+  background-color: #e74c3c;
+  color: white;
+}
+/* line 32, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.shift-up .rst-other-versions {
+  display: block;
+}
+/* line 34, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions {
+  font-size: 90%;
+  padding: 12px;
+  color: gray;
+  display: none;
+}
+/* line 39, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions hr {
+  display: block;
+  height: 1px;
+  border: 0;
+  margin: 20px 0;
+  padding: 0;
+  border-top: solid 1px #413d3d;
+}
+/* line 46, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions dd {
+  display: inline-block;
+  margin: 0;
+}
+/* line 49, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions .rst-other-versions dd a {
+  display: inline-block;
+  padding: 6px;
+  color: #fcfcfc;
+}
+/* line 53, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge {
+  width: auto;
+  bottom: 20px;
+  right: 20px;
+  left: auto;
+  border: none;
+  max-width: 300px;
+}
+/* line 60, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge .icon-book {
+  float: none;
+}
+/* line 62, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge.shift-up .rst-current-version {
+  text-align: right;
+}
+/* line 64, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge.shift-up .rst-current-version .icon-book {
+  float: left;
+}
+/* line 66, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+.rst-versions.rst-badge .rst-current-version {
+  width: auto;
+  height: 30px;
+  line-height: 30px;
+  padding: 0 6px;
+  display: block;
+  text-align: center;
+}
+
+@media screen and (max-width: 768px) {
+  /* line 75, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  .rst-versions {
+    width: 85%;
+    display: none;
+  }
+  /* line 78, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  .rst-versions.shift {
+    display: block;
+  }
+
+  /* line 80, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_badge.sass */
+  img {
+    width: 100%;
+    height: auto;
+  }
+}
+/* line 3, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content img {
+  max-width: 100%;
+  height: auto !important;
+}
+/* line 6, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .section > img {
+  margin-bottom: 24px;
+}
+/* line 10, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .note p.last, .rst-content .note p.first, .rst-content .attention p.last, .rst-content .attention p.first, .rst-content .caution p.last, .rst-content .caution p.first, .rst-content .danger p.last, .rst-content .danger p.first, .rst-content .error p.last, .rst-content .error p.first, .rst-content .hint p.last, .rst-content .hint p.first, .rst-content .important p.last, .rst-content .important p.first, .rst-content .tip p.last, .rst-content .tip p.first, .rst-content .warning p.last, .rst-content .warning p.first {
+  margin-bottom: 0;
+}
+/* line 12, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .admonition-title {
+  font-weight: bold;
+}
+/* line 16, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .admonition-title:before {
+  margin-right: 4px;
+}
+/* line 30, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .topic-title {
+  font-weight: bold;
+  margin-bottom: 12px;
+}
+/* line 33, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .toc-backref {
+  color: #404040;
+}
+/* line 35, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .align-right {
+  float: right;
+  margin: 0px 0px 24px 24px;
+}
+/* line 38, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .align-left {
+  float: left;
+  margin: 0px 24px 24px 0px;
+}
+/* line 42, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content h1 .headerlink, .rst-content h2 .headerlink, .rst-content h3 .headerlink, .rst-content h4 .headerlink, .rst-content h5 .headerlink, .rst-content h6 .headerlink, .rst-content dl dt .headerlink {
+  display: none;
+  visibility: hidden;
+  font-size: 14px;
+}
+/* line 47, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content h1 .headerlink:after, .rst-content h2 .headerlink:after, .rst-content h3 .headerlink:after, .rst-content h4 .headerlink:after, .rst-content h5 .headerlink:after, .rst-content h6 .headerlink:after, .rst-content dl dt .headerlink:after {
+  visibility: visible;
+  content: "\f0c1";
+  font-family: fontawesome-webfont;
+  display: inline-block;
+}
+/* line 52, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content h1:hover .headerlink, .rst-content h2:hover .headerlink, .rst-content h3:hover .headerlink, .rst-content h4:hover .headerlink, .rst-content h5:hover .headerlink, .rst-content h6:hover .headerlink, .rst-content dl dt:hover .headerlink {
+  display: inline-block;
+}
+/* line 55, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .sidebar {
+  float: right;
+  width: 40%;
+  display: block;
+  margin: 0 0 24px 24px;
+  padding: 24px;
+  background: #f3f6f6;
+  border: solid 1px #e1e4e5;
+}
+/* line 63, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .sidebar p, .rst-content .sidebar ul, .rst-content .sidebar dl {
+  font-size: 90%;
+}
+/* line 65, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .sidebar .last {
+  margin-bottom: 0;
+}
+/* line 67, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .sidebar .sidebar-title {
+  display: block;
+  font-family: "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, sans-serif;
+  font-weight: bold;
+  background: #e1e4e5;
+  padding: 6px 12px;
+  margin: -24px;
+  margin-bottom: 24px;
+  font-size: 100%;
+}
+/* line 83, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.citation, .rst-content table.docutils.footnote {
+  background: none;
+  border: none;
+  color: #999999;
+}
+/* line 87, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.citation td, .rst-content table.docutils.citation tr, .rst-content table.docutils.footnote td, .rst-content table.docutils.footnote tr {
+  border: none;
+  background-color: transparent !important;
+  white-space: normal;
+}
+/* line 91, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.citation td.label, .rst-content table.docutils.footnote td.label {
+  padding-left: 0;
+  padding-right: 0;
+  vertical-align: top;
+}
+/* line 96, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content .footnote-reference, .rst-content .citation-reference {
+  vertical-align: super;
+  font-size: 90%;
+}
+/* line 100, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.field-list {
+  border: none;
+}
+/* line 103, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.field-list td {
+  border: none;
+}
+/* line 105, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.field-list .field-name {
+  padding-right: 5px;
+  text-align: left;
+}
+/* line 108, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content table.docutils.field-list .field-body {
+  text-align: left;
+  padding-left: 0;
+}
+/* line 113, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dt {
+  display: inline-block;
+  margin: 6px 0;
+  font-size: 90%;
+  line-height: normal;
+  background: #cccccc;
+  color: #333333;
+  border: none;
+  border-left: solid 3px #999999;
+  padding: 6px;
+}
+/* line 123, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dt .headerlink {
+  color: #404040;
+  font-size: 100% !important;
+}
+/* line 128, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dt:first-child {
+  margin-top: 0;
+}
+/* line 130, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dd {
+  margin-left: 24px;
+}
+/* line 134, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl tt.descname, .rst-content dl tt.descclassname {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  font-size: 100% !important;
+}
+/* line 139, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl tt.descname {
+  font-weight: bold;
+}
+/* line 143, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dl dt {
+  display: inline-block;
+  margin-bottom: 6px;
+  font-size: 90%;
+  background: none;
+  border: none;
+}
+/* line 150, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content dl dl dt .headerlink {
+  color: #404040;
+  font-size: 100% !important;
+}
+/* line 158, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content tt {
+  white-space: nowrap;
+  max-width: 100%;
+  background: white;
+  border: solid 1px #e1e4e5;
+  color: #404040;
+  font-size: 80%;
+  padding: 0 5px;
+  font-family: "Incosolata", "Consolata", "Monaco", monospace;
+  overflow-x: auto;
+}
+/* line 169, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content tt big, .rst-content tt em {
+  font-size: 100% !important;
+  line-height: normal;
+}
+/* line 173, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content tt .xref, a .rst-content tt {
+  font-weight: bold;
+}
+/* line 176, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content blockquote {
+  margin-left: 24px;
+  line-height: 24px;
+  margin-bottom: 24px;
+}
+/* line 182, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content #search-results .search li {
+  margin-bottom: 24px;
+  border-bottom: solid 1px #e1e4e5;
+  padding-bottom: 24px;
+}
+/* line 186, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content #search-results .search li:first-child {
+  border-top: solid 1px #e1e4e5;
+  padding-top: 24px;
+}
+/* line 189, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content #search-results .search li a {
+  font-size: 120%;
+  margin-bottom: 12px;
+  display: inline-block;
+}
+/* line 193, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+.rst-content #search-results .context {
+  color: gray;
+  font-size: 90%;
+}
+
+@media screen and (max-width: 480px) {
+  /* line 199, /home/tony/workspace/sphinx_rtd_theme/sass/_theme_rst.sass */
+  .rst-content .sidebar {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
As it currently stands, all inline expressions in the theme show red links with boxes (because of extending `code`). In addition, css rules for code styles were incorrect in their current form.

The styling in here is far easier on the eyes, it articulates 1.) more accurate css rules for how to touch code in the sphinx output 2.) creates more doc examples for visual test cases.

My intention for this is to be merged and then it can be tweaked further by others since there are new tests and clearer sass rules.

Further specifics can be seen by reading my diff.
