### PR TITLE
Github badge via theme option

### DIFF
--- a/demo_docs/source/conf.py
+++ b/demo_docs/source/conf.py
@@ -106,7 +106,9 @@ html_theme = 'sphinx_rtd_theme'
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
-#html_theme_options = {}
+html_theme_options = {
+    # 'github_fork':'snide/sphinx_rtd_theme'
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 html_theme_path = ["../.."]

--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -265,6 +265,9 @@ footer
     margin-left: 0
     .wy-nav-content
       padding: $gutter
+      .github_fork img
+        max-width: initial
+        width: auto
     &.shift
       position: fixed
       min-width: 100%

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -26,5 +26,14 @@
   {%- endif %}
   </p>
 
-  {% trans %}<a href="https://www.github.com/snide/sphinx_rtd_theme">Sphinx theme</a> provided by <a href="http://readthedocs.org">Read the Docs</a>{% endtrans %}
+  {% trans %}<a href="https://www.github.com/snide/sphinx_rtd_theme">Sphinx
+  theme</a> provided by <a href="http://readthedocs.org">Read the Docs</a>{% endtrans %}
+
+  {% if theme_github_fork %}
+  <a href="http://github.com/{{ theme_github_fork }}" class="github_fork">
+  <img style="position: fixed; top: 0; right: 0; border: 0;"
+    src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
+    alt="Fork me on GitHub" />
+  </a>
+  {% endif %}
 </footer>

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -4,4 +4,5 @@ stylesheet = css/theme.css
 
 [options]
 typekit_id = hiw1hhg
+github_fork = 
 analytics_id = 


### PR DESCRIPTION
From https://github.com/mitsuhiko/flask-sphinx-themes implementation.

Testable by uncommenting conf.py.

I want this to be a proof of concept - to work completely this needs an option on the project page for readthedocs.org.
