### PR TITLE
Fix CSS for level 2 navigation

### DIFF
--- a/sass/_theme_layout.sass
+++ b/sass/_theme_layout.sass
@@ -66,8 +66,9 @@
     &:hover
       background: $section-background-color
   // This is the on state for pages beyond second level
-  li.tocktree-l2.current > a
+  li.toctree-l2.current > a
     background: darken($section-background-color, 20%)
+    padding: $gutter / 4 $gutter * 1.5 
   li.current ul
     display: block
   li ul


### PR DESCRIPTION
The sidebar navigation CSS is badly broken when documents are used in the `toctree` (as opposed to just section headers). This is due to both a typo in `_theme_layout.sass` as well as a single missing CSS rule.
## BEFORE

![screenshot-1](https://f.cloud.github.com/assets/369261/1848783/36b2d15e-769a-11e3-9d2f-7cd5044e7ac7.png)

---

![screenshot-4](https://f.cloud.github.com/assets/369261/1848792/552fdf00-769a-11e3-8219-9af20f1c53e9.png)

---

![screenshot-5](https://f.cloud.github.com/assets/369261/1848793/571a9724-769a-11e3-8273-371c99d651f3.png)
## AFTER

![screenshot-1](https://f.cloud.github.com/assets/369261/1848783/36b2d15e-769a-11e3-9d2f-7cd5044e7ac7.png)

---

![screenshot](https://f.cloud.github.com/assets/369261/1848796/8736b4f6-769a-11e3-85f6-785eb82cb174.png)

---

![screenshot-3](https://f.cloud.github.com/assets/369261/1848798/8e2a9b06-769a-11e3-9231-5e5f2fcce60f.png)
