### PR TITLE
Add parents to breadcrumbs

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -3,7 +3,7 @@
     {% for doc in parents %}
         <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
     {% endfor %}
-  <li><a href="">{{ title }}</a></li>
+  <li>{{ title }}</li>
     <li class="wy-breadcrumbs-aside">
       {% if display_github %}
         <a href="https://github.com/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}.rst" class="icon icon-github"> Edit on GitHub</a>


### PR DESCRIPTION
Adds parent documents (complete with working links) to the breadcrumb trail. This also at least partially addresses #76.

![screenshot-7](https://f.cloud.github.com/assets/369261/1848921/fd5676f8-769f-11e3-9310-8226f8de5b41.png)
