### PR TITLE
Specify an empty dependencies set in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "sphinx_rtd_theme",
   "version": "0.0.11",
   "private": true,
+  "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-contrib-compass": "~0.2.0",


### PR DESCRIPTION
NPM goes really crazy without this. You'll get a lot of `called_on_non_object` errors when trying to perform (even global) install operations.
