### PR TITLE
Add block for toctree.

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -89,6 +89,7 @@
       </div>
 
       <div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="main navigation">
+        {% block toctree %}
         {% set toctree = toctree(maxdepth=2, collapse=False, includehidden=True) %}
         {% if toctree %}
             {{ toctree }}
@@ -96,6 +97,7 @@
             <!-- Local TOC -->
             <div class="local-toc">{{ toc }}</div>
         {% endif %}
+        {% endblock %}
       </div>
       &nbsp;
     </nav>


### PR DESCRIPTION
For my project I need three levels of table of content in the left menu. This can be easily done in my project in _templates/page.html, only if there was appropriate {% block %} for it. The patch below adds such block.
