### PR TITLE
Hide the superfluous and broken search box in single-page HTML builds

### DIFF
--- a/sphinx_rtd_theme/searchbox.html
+++ b/sphinx_rtd_theme/searchbox.html
@@ -1,7 +1,9 @@
+{%- if builder != 'singlehtml' %}
 <div role="search">
-  <form id ="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
+  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
     <input type="text" name="q" placeholder="Search docs" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>
 </div>
+{%- endif %}


### PR DESCRIPTION
The search box is non-functional in `make singlehtml` builds. This patch hides it in that build mode, just as Sphinx's default theme does as well.
