### PR TITLE
Fix: #719 Fix literals going over page width

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -288,6 +288,7 @@
   // These are the "literals" that get spit out when you mark stuff as ``code`` as your write.
   tt, code
     @extend code
+    display: block
     color: $black
     font-family: $code-font-family
     padding: 2px 5px


### PR DESCRIPTION
THis should fix the literal example on https://sphinx-rtd-theme.readthedocs.io/en/stable/demo/demo.html#inline-markup

Fixes: #719