### PR TITLE
Inherent sphinx base css

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -66,6 +66,7 @@
   {%- endblock %}
 
   {# CSS #}
+  <link rel="stylesheet" href="{{ pathto('_static/basic.css', 1) }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
   <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- for css in css_files %}


### PR DESCRIPTION
This adds https://github.com/sphinx-doc/sphinx/blob/master/sphinx/themes/basic/static/basic.css_t to our css stack. There might be some side effects so we will have to look at this carefully before merging.

Fix #746