### PR TITLE
Breadcrumbs use home icon instead of "Docs"

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -28,7 +28,7 @@
 
   <ul class="wy-breadcrumbs">
     {% block breadcrumbs %}
-      <li><a href="{{ pathto(master_doc) }}">{{ _('Docs') }}</a> &raquo;</li>
+      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home"></a> &raquo;</li>
         {% for doc in parents %}
           <li><a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;</li>
         {% endfor %}


### PR DESCRIPTION
This gives more room for longer breadcrumbs and makes the theme a little bit more generic. For example, people might use the theme for other purposes then hosting "docs".