### PR TITLE
Horizontal Lists: Use full width

### DIFF
--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -232,7 +232,7 @@
 
   // Horizontal lists have multiple columns; use full width
   .hlist
-	  width: 100%
+    width: 100%
 
   // Tables! Sphinx LOVES TABLES. Most of wyrm assumes you're only going to use a table as a table
   // so I have to write a bunch of unique stuff for Sphinx to style them up differently like it's 2003.

--- a/sass/_theme_rst.sass
+++ b/sass/_theme_rst.sass
@@ -230,6 +230,10 @@
     line-height: 0
     font-size: 90%
 
+  // Horizontal lists have multiple columns; use full width
+  .hlist
+	  width: 100%
+
   // Tables! Sphinx LOVES TABLES. Most of wyrm assumes you're only going to use a table as a table
   // so I have to write a bunch of unique stuff for Sphinx to style them up differently like it's 2003.
   table.docutils.citation, table.docutils.footnote


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/15183467/61092950-5f807280-a416-11e9-8da6-2a3939a90c9f.png)

After:

![image](https://user-images.githubusercontent.com/15183467/61092921-424ba400-a416-11e9-841d-c7117f970bf0.png)
