### PR TITLE
Comment on why bourbon-neat is pinned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 *.map
 .ropeproject/
 .ruby-version
-bin/
 dist/
 bower_components/
 include/

--- a/bin/preinstall.js
+++ b/bin/preinstall.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const package = require('../package.json');
+
+// Sorry everyone, this is the closest we can get to commenting on package.json
+// dependencies :(
+if (package.devDependencies['bourbon-neat'] !== '~1.9') {
+    // Wyrm is not compatible with Neat 2.0+, and Neat 1.9 at least pins a
+    // node-sass version that doesn't require Python 2. The changes to Wyrm to
+    // support Neat 2.0+ are all fairly minor changes, but it deeply affects the
+    // grid system and might be more of a liability than an old release of Neat.
+    // See: https://github.com/readthedocs/sphinx_rtd_theme/pull/771
+    console.error(
+        'bourbon-neat 1.9 is required, Wyrm is not compatible with Neat 2.0+'
+    );
+    process.exit(1);
+}

--- a/bin/preinstall.js
+++ b/bin/preinstall.js
@@ -11,7 +11,10 @@ if (package.devDependencies['bourbon-neat'] !== '~1.9') {
     // grid system and might be more of a liability than an old release of Neat.
     // See: https://github.com/readthedocs/sphinx_rtd_theme/pull/771
     console.error(
-        'bourbon-neat 1.9 is required, Wyrm is not compatible with Neat 2.0+'
+        'bourbon-neat 1.9 is required, Wyrm is not compatible with Neat 2.0+.'
+    );
+    console.error(
+        'The expected selector for the bourbon-neat dependency in package.json is "~1.9".'
     );
     process.exit(1);
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
-    "build": "webpack --config webpack.prod.js"
+    "build": "webpack --config webpack.prod.js",
+    "preinstall": "bin/preinstall.js"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
This will actually fail `npm install` if you try upgrading the version.