### PR TITLE
Run webpack js through Prettier JS formatter

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,48 +1,52 @@
-const path = require('path');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const path = require("path");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
 module.exports = {
-  entry: './src/index.js',
+  entry: "./src/index.js",
   output: {
-    filename: 'js/theme.js',
-    path: path.resolve(__dirname, 'sphinx_rtd_theme/static')
+    filename: "js/theme.js",
+    path: path.resolve(__dirname, "sphinx_rtd_theme/static")
   },
   module: {
     rules: [
       {
-        test: require.resolve('./src/theme.js'),
-        use: 'imports-loader?this=>window'
+        test: require.resolve("./src/theme.js"),
+        use: "imports-loader?this=>window"
       },
       {
         test: /\.sass$/,
-        use: [{
-          loader: MiniCssExtractPlugin.loader
-        },
-        {
-          loader: "css-loader"
-        },
-        {
-          loader: "sass-loader?indentedSyntax",
-          options: {
-            includePaths: [
-              'node_modules/bourbon/app/assets/stylesheets',
-              'node_modules/bourbon-neat/app/assets/stylesheets',
-              'node_modules/font-awesome/scss',
-              'node_modules/wyrm/sass'
-            ]
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader
+          },
+          {
+            loader: "css-loader"
+          },
+          {
+            loader: "sass-loader?indentedSyntax",
+            options: {
+              includePaths: [
+                "node_modules/bourbon/app/assets/stylesheets",
+                "node_modules/bourbon-neat/app/assets/stylesheets",
+                "node_modules/font-awesome/scss",
+                "node_modules/wyrm/sass"
+              ]
+            }
           }
-        }]
+        ]
       },
       {
         test: /\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
-        use: [{
-          loader: 'file-loader',
-          options: {
-            name: '[name].[ext]?[hash]',
-            outputPath: 'fonts/',
-            publicPath: '../fonts/',
+        use: [
+          {
+            loader: "file-loader",
+            options: {
+              name: "[name].[ext]?[hash]",
+              outputPath: "fonts/",
+              publicPath: "../fonts/"
+            }
           }
-        }]
+        ]
       }
     ]
   },
@@ -50,7 +54,7 @@ module.exports = {
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
       // both options are optional
-      filename: 'css/theme.css'
+      filename: "css/theme.css"
     })
-  ],
+  ]
 };

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -1,34 +1,31 @@
-const path = require('path');
-const merge = require('webpack-merge');
-const exec = require('child_process').exec;
-const WatchPlugin = require('webpack-watch-files-plugin').default;
-const ShellPlugin = require('webpack-shell-plugin');
-const common = require('./webpack.common.js');
+const path = require("path");
+const merge = require("webpack-merge");
+const exec = require("child_process").exec;
+const WatchPlugin = require("webpack-watch-files-plugin").default;
+const ShellPlugin = require("webpack-shell-plugin");
+const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
-  mode: 'development',
+  mode: "development",
   watch: true,
   devServer: {
-    contentBase: path.join(__dirname, 'docs/build/html'),
+    contentBase: path.join(__dirname, "docs/build/html"),
     watchContentBase: true,
     compress: false,
     port: 1919,
     hot: false,
     liveReload: true,
-    publicPath: '/_static/'
+    publicPath: "/_static/"
   },
   plugins: [
     new WatchPlugin({
-      files: [
-        './docs/**/*.rst',
-        './docs/**/*.py',
-      ]
+      files: ["./docs/**/*.rst", "./docs/**/*.py"]
     }),
     new ShellPlugin({
-      onBuildEnd: ['make -C docs clean html'],
+      onBuildEnd: ["make -C docs clean html"],
       // dev=false here to force every build to trigger make, the default is
       // first build only.
-      dev: false,
-    }),
+      dev: false
+    })
   ]
 });

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -1,11 +1,11 @@
-const merge = require('webpack-merge');
-const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
-const common = require('./webpack.common.js');
+const merge = require("webpack-merge");
+const OptimizeCssAssetsPlugin = require("optimize-css-assets-webpack-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
+const common = require("./webpack.common.js");
 
 module.exports = merge(common, {
-  mode: 'production',
+  mode: "production",
   optimization: {
-    minimizer: [new TerserPlugin(), new OptimizeCssAssetsPlugin({})],
-  },
+    minimizer: [new TerserPlugin(), new OptimizeCssAssetsPlugin({})]
+  }
 });


### PR DESCRIPTION
Uses Prettier with no options. I'm fine accepting this as the default
style for our Javascript and autoformatting src/js/*.js as well. I left
those changes out for now.