### PR TITLE
Add webpack commands into setup.py

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -94,9 +94,11 @@ To release a new version of the theme, core team will take the following steps:
    (with regards to alpha release and development versions). The version
    increment should reflect these releases and any potentially breaking changes.
 #. Update the changelog (``docs/changelog.rst``) with the version information.
-#. Run ``npm run build`` to rebuild all the theme assets.
-#. Run ``python setup.py update_translations`` to compile new translation files and update Transifex
-#. Commit that change.
+#. Run ``python setup.py update_translations`` to compile new translation files
+   and update Transifex.
+#. Run ``python setup.py build`` to rebuild all the theme assets and the Python
+   package.
+#. Commit these changes.
 #. Tag the release in git: ``git tag $NEW_VERSION``.
 #. Push the tag to GitHub: ``git push --tags origin``.
 #. Upload the package to PyPI:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class WebpackBuildCommand(setuptools.command.build_py.build_py):
     def run(self):
         if not 'CI' in os.environ:
             subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
-        super(WebpackBuildCommand, self).run()
+        WebpackBuildCommand.run(self)
 
 
 class WebpackDevelopCommand(distutils.cmd.Command):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class WebpackBuildCommand(setuptools.command.build_py.build_py):
     def run(self):
         if not 'CI' in os.environ:
             subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
-        super().run()
+        super(WebpackBuildCommand, self).run()
 
 
 class WebpackDevelopCommand(distutils.cmd.Command):

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class WebpackDevelopCommand(distutils.cmd.Command):
 
     def run(self):
         subprocess.run(
-            ["webpack-dev-server", "--open", "--config", "webpack.dev.js"],
+            ["node_modules/.bin/webpack-dev-server", "--open", "--config", "webpack.dev.js"],
             check=True
         )
 

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,37 @@
 
 import subprocess
 import distutils.cmd
+import setuptools.command.build_py
 from io import open
 from setuptools import setup
+
+
+class WebpackBuildCommand(setuptools.command.build_py.build_py):
+
+    """Prefix Python build with Webpack asset build"""
+
+    def run(self):
+        subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
+        super().run()
+
+
+class WebpackDevelopCommand(distutils.cmd.Command):
+
+    description = "Run Webpack dev server"
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        subprocess.run(
+            ["webpack-dev-server", "--open", "--config", "webpack.dev.js"],
+            check=True
+        )
 
 
 class UpdateTranslationsCommand(distutils.cmd.Command):
@@ -47,8 +76,8 @@ class TransifexCommand(distutils.cmd.Command):
         pass
 
     def run(self):
-        subprocess.run(['tx', 'push', '--source'])
-        subprocess.run(['tx', 'pull'])
+        subprocess.run(['tx', 'push', '--source'], check=True)
+        subprocess.run(['tx', 'pull'], check=True)
 
 
 setup(
@@ -63,6 +92,8 @@ setup(
     cmdclass={
         'update_translations': UpdateTranslationsCommand,
         'transifex': TransifexCommand,
+        'build_py': WebpackBuildCommand,
+        'watch': WebpackDevelopCommand,
     },
     zip_safe=False,
     packages=['sphinx_rtd_theme'],

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@
 
 """
 
+import os
 import subprocess
 import distutils.cmd
 import setuptools.command.build_py
@@ -17,7 +18,8 @@ class WebpackBuildCommand(setuptools.command.build_py.build_py):
     """Prefix Python build with Webpack asset build"""
 
     def run(self):
-        subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
+        if not 'CI' in os.environ:
+            subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
         super().run()
 
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ class WebpackBuildCommand(setuptools.command.build_py.build_py):
     def run(self):
         if not 'CI' in os.environ:
             subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
-        WebpackBuildCommand.run(self)
+        setuptools.command.build_py.build_py.run(self)
 
 
 class WebpackDevelopCommand(distutils.cmd.Command):

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ class WebpackBuildCommand(setuptools.command.build_py.build_py):
 
     def run(self):
         if not 'CI' in os.environ:
-            subprocess.run(['webpack', '--config', 'webpack.prod.js'], check=True)
+            subprocess.run(['node_modules/.bin/webpack', '--config', 'webpack.prod.js'], check=True)
         setuptools.command.build_py.build_py.run(self)
 
 


### PR DESCRIPTION
This is a POC that shows building webpack through standard `setup.py`
commands. Any call to `setup.py build` or `bdist` or `sdist` will
trigger a Webpack build of the assets first. A non-zero exit code will
halt the process.

Also, moved the `npm run dev` command, which here is `python setup.py
watch`, though there is perhaps something better here. There is already
`python setup.py develop`, which has a separate function, so I don't
want to collide there.

Example output here:
https://gist.github.com/agjohnson/cdaab364fe598daa7f3bef750cfb84dd

Refs #797