### PR TITLE
Make highlight-color lighter yellow

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -220,7 +220,6 @@
     background: $highlight-color
     display: inline-block
     font-weight: bold
-    font-style: italic
     color: #404040
     border-bottom: 2px solid rgb(255, 190, 0)
     padding: 0 $base-line-height / 4

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -220,6 +220,7 @@
     background: $highlight-color
     display: inline-block
     font-weight: bold
+    font-style: italic
     color: #404040
     border-bottom: 2px solid rgb(255, 190, 0)
     padding: 0 $base-line-height / 4

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -221,9 +221,7 @@
     display: inline-block
     font-weight: bold
     color: #404040
-    border: 0 0 2px 0
-    border-color: 0 0 rgb(255, 190, 0)
-    border-style: 0 0 solid 0
+    border-bottom: 2px solid rgb(255, 190, 0)
     padding: 0 $base-line-height / 4
 
   // These are the little citation links [1] that show up within paragraphs.

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -220,6 +220,10 @@
     background: $highlight-color
     display: inline-block
     font-weight: bold
+    color: #404040
+    border: 0 0 2px 0
+    border-color: 0 0 rgb(255, 190, 0)
+    border-style: 0 0 solid 0
     padding: 0 $base-line-height / 4
 
   // These are the little citation links [1] that show up within paragraphs.

--- a/src/sass/_theme_variables.sass
+++ b/src/sass/_theme_variables.sass
@@ -59,7 +59,7 @@ $sidebar-border-color:                $table-border-color
 $sidebar-title-background-color:      $table-border-color
 
 // Sphinx highlight color
-$highlight-color:                     rgba(255, 255, 0, 0.4)
+$highlight-color:                     rgba(255, 220, 0, 0.5)
 
 $base-font-family:                    "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif
 $custom-font-family:                  "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, sans-serif

--- a/src/sass/_theme_variables.sass
+++ b/src/sass/_theme_variables.sass
@@ -59,7 +59,7 @@ $sidebar-border-color:                $table-border-color
 $sidebar-title-background-color:      $table-border-color
 
 // Sphinx highlight color
-$highlight-color:                     $yellow
+$highlight-color:                     rgba(255, 255, 0, 0.4)
 
 $base-font-family:                    "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif
 $custom-font-family:                  "Roboto Slab", "ff-tisa-web-pro", "Georgia", Arial, sans-serif


### PR DESCRIPTION
Small change to make the highlight-color a little lighter.

I found that with this change it's easier to read what's highlighted, but still easily realized where is the highlighted text.

### Before

![Screenshot_2019-07-28_16-51-54](https://user-images.githubusercontent.com/244656/62008940-260b6f00-b159-11e9-8316-1fb94f023e29.png)

### After

![Screenshot_2019-07-28_16-48-47](https://user-images.githubusercontent.com/244656/62008941-2ad02300-b159-11e9-82e6-a0d24698189b.png)


> NOTE: I don't know how to build these .sass files, so maybe the change is completely wrong.