### PR TITLE
Remove "Free document hosting provided by Read the Docs" message

### DIFF
--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -29,10 +29,6 @@
             <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
           </dd>
       </dl>
-      <hr/>
-      {% trans %}Free document hosting provided by{% endtrans %} <a href="http://www.readthedocs.org">Read the Docs</a>.
-
     </div>
   </div>
 {% endif %}
-


### PR DESCRIPTION
We don't have Read the Docs specific logic anymore in the theme. It seems correct to remove this message as well.

Besides, the correct message is added by the Footer API call when docs are hosted on Read the Docs.

Related to #578 