### PR TITLE
Add automatic deployment to pypi when tag is pushed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,24 @@ install:
   - pip install sphinx
 script:
   - tox
-  
+
 branches:
   only:
   - master
+
+jobs:
+  include:
+    - stage: deploy
+      python: 3.6
+      env:
+        - TOXENV=py36-sphinx18
+      deploy:
+        # production pypi
+        - provider: pypi
+          distributions: sdist bdist_wheel
+          user: deply_username
+          password:
+            secure:
+          on:
+            branch: master
+            tags: true

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ import setuptools.command.build_py
 from io import open
 from setuptools import setup
 
-
 class WebpackBuildCommand(setuptools.command.build_py.build_py):
 
     """Prefix Python build with Webpack asset build"""
@@ -87,6 +86,10 @@ setup(
     name='sphinx_rtd_theme',
     version='0.4.3.dev0',
     url='https://github.com/rtfd/sphinx_rtd_theme/',
+    use_scm_version = {
+        'write_to': 'src/sphinx_rtd_theme/__sphinx_rtd_theme_version__.py'
+    },
+    setup_requires=['setuptools_scm'],
     license='MIT',
     author='Dave Snider, Read the Docs, Inc. & contributors',
     author_email='dev@readthedocs.org',

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -8,9 +8,10 @@ from os import path
 
 import sphinx
 
+from .__sphinx_rtd_theme_version__ import version as sphinx_rtd_theme_version
 
-__version__ = '0.4.3.dev0'
-__version_full__ = __version__
+__version__ = sphinx_rtd_theme_version
+__version_full__ = sphinx_rtd_theme_version
 
 
 def get_html_theme_path():


### PR DESCRIPTION
`setuptools_scm` works that it provides a version even when you build it
locally and it generates the version into a file at the time of
packaging, which means there is no run-time-dependenty on the
`setuptools_scm` package later on (and also no dependency on git, or
internet access). This makes a simplified release flow, because it
enables you to just add a tag and CI pushes the end package to the PyPi
for end users to use.

Option is also to provide development packages, etc. (just the matter of
how far we want to take it). There is no required tag name, although we
should follow some of the standard formats of Major.minor.patch or
whatever it is preferred.

Before merging we should fill in the secure password (hashed with original repo) and username of the maintainer for pypi. This is added as allow edits from maintainers so that they can add all the details before merging.

closes #822 and #812 if we decide to go this way.