### PR TITLE
Defer loading JS

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -30,11 +30,11 @@
 
   {# JAVASCRIPTS #}
   {%- block scripts %}
-  <script type="text/javascript" src="{{ pathto('_static/js/modernizr.min.js', 1) }}"></script>
+  <script type="text/javascript" src="{{ pathto('_static/js/modernizr.min.js', 1) }}" defer></script>
   {%- if not embedded %}
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
     {% if sphinx_version >= "1.8.0" %}
-      <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+      <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}" defer></script>
       {%- for scriptfile in script_files %}
         {{ js_tag(scriptfile) }}
       {%- endfor %}
@@ -51,10 +51,10 @@
           };
       </script>
       {%- for scriptfile in script_files %}
-        <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+        <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}" defer></script>
       {%- endfor %}
     {% endif %}
-    <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}" defer></script>
 
     {# OPENSEARCH #}
     {%- if use_opensearch %}


### PR DESCRIPTION
We use this theme as the base for our custom Sphinx theme in the Dask project. We've noticed some render flicker when we load the page and form looking at the profiler this seems to be due to JavaScript resources being fetched and executed before the style sheets.

This PR adds the defer attribute to the script resources which will fetch them asynchronously and execute them once the rest of the page has finished loading. Alternatively the script tags could be moved to below other DOM resources.