### PR TITLE
package.json: remove option '--open' from script 'dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.4.3",
   "private": true,
   "scripts": {
-    "dev": "webpack-dev-server --open --config webpack.dev.js",
+    "dev": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",
     "preinstall": "bin/preinstall.js"
   },


### PR DESCRIPTION
When `yarn dev` is executed inside a docker container, `--open` requires a browser to be installed and an X11 server to be shared. Instead, it is more *idiomatic* to just bind a port and remove the option.

Developers that want to execute the script on the host and have the browser opened automatically, can still do so: `yarn dev --open`.

In fact, the command inside the container needs to be `yarn dev --host 0.0.0.0`. Therefore, an alternative solution would be to keep script `dev` and add another one (say `dev-docker`).