### PR TITLE
update and move 'Previous' and 'Next' buttons

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -68,15 +68,19 @@
     {% endblock %}
   </ul>
 
-  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-  <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
-      {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
-      {% endif %}
-      {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
-      {% endif %}
-  </div>
+  {% if (theme_prev_next_buttons_location in ['top', 'both']) and (next or prev) %}
+  <hr class="nomargin"/>
+  <span class="contentinfo" role="navigation" aria-label="breadcrumb navigation">
+    {% if prev %}
+    <span class="prevnext"><a href="{{ prev.link|e }}" class="float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a></span>
+    {% endif %}
+    <span class="contentinfo-content"></span>
+    {% if next %}
+    <span class="prevnext"><a href="{{ next.link|e }}" class="float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a></span>
+    {% endif %}
+  </span>
+  <hr class="marginbot"/>
+  {% else %}
+    <hr/>
   {% endif %}
-  <hr/>
 </div>

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -1,56 +1,58 @@
 <footer>
-  {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
-      {% endif %}
-      {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
-      {% endif %}
-    </div>
-  {% endif %}
-
   <hr/>
+  <div class="contentinfo">
+    <span class="prevnext" role="navigation" aria-label="footer navigation">
+      {% if (theme_prev_next_buttons_location in ['bottom', 'both']) and prev %}
+        <a href="{{ prev.link|e }}" class="float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+      {% endif %}
+    </span>
+    <div class="contentinfo-content" role="contentinfo">
 
-  <div role="contentinfo">
-    <p>
-    {%- if show_copyright %}
-      {%- if hasdoc('copyright') %}
-        {% set path = pathto('copyright') %}
-        {% set copyright = copyright|e %}
-        &copy; <a href="{{ path }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright }}
-      {%- else %}
-        {% set copyright = copyright|e %}
-        &copy; {% trans %}Copyright{% endtrans %} {{ copyright }}
+      {%- if show_copyright %}
+      <p>
+        {%- if hasdoc('copyright') %}
+          {% set path = pathto('copyright') %}
+          {% set copyright = copyright|e %}
+          &copy; <a href="{{ path }}">{% trans %}Copyright{% endtrans %}</  a> {{ copyright }}
+        {%- else %}
+          {% set copyright = copyright|e %}
+          &copy; {% trans %}Copyright{% endtrans %} {{ copyright }}
+        {%- endif %}
+      </p>
       {%- endif %}
-    {%- endif %}
 
-    {%- if build_id and build_url %}
-      <span class="build">
-        {# Translators: Build is a noun, not a verb #}
-        {% trans %}Build{% endtrans %}
-        <a href="{{ build_url }}">{{ build_id }}</a>.
-      </span>
-    {%- elif commit %}
-      <span class="commit">
-        {% trans %}Revision{% endtrans %} <code>{{ commit }}</code>.
-      </span>
-    {%- elif last_updated %}
-      <span class="lastupdated">
-        {% trans last_updated=last_updated|e %}Last updated on {{ last_updated }}.{% endtrans %}
-      </span>
-    {%- endif %}
+      {%- if build_id and build_url %}
+        <p>
+        <span class="build">
+          {# Translators: Build is a noun, not a verb #}
+          {% trans %}Build{% endtrans %}
+          <a href="{{ build_url }}">{{ build_id }}</a>.
+        </span>
+      {%- elif commit %}
+        <span class="commit">
+          {% trans %}Revision{% endtrans %} <code>{{ commit }}</code>.
+        </span>
+      {%- elif last_updated %}
+        <span class="lastupdated">
+          {% trans last_updated=last_updated|e %}Last updated on {{   last_updated }}.{% endtrans %}
+        </span>
+        </p>
+      {%- endif %}
 
-    </p>
-  </div>
-
-  {%- if show_sphinx %}
-    {% set sphinx_web = '<a href="http://sphinx-doc.org/">Sphinx</a>' %}
-    {% set readthedocs_web = '<a href="https://readthedocs.org">Read the Docs</a>'  %}
+      {%- if show_sphinx %}
+      <p>
+      {% set sphinx_web = '<a href="http://sphinx-doc.org/">Sphinx</a>' %}
+      {% set readthedocs_web = '<a href="https://readthedocs.org">Read the Docs</a>'  %}
       {% trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %} <a href="https://github.com/rtfd/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a> {% trans %}provided by {{ readthedocs_web }}{% endtrans %}.
-  {%- endif %}
+      {%- endif %}
+      </p>
 
+    </div>
+    <span class="prevnext" role="navigation" aria-label="footer navigation">
+      {% if (theme_prev_next_buttons_location in ['bottom', 'both']) and next %}
+        <a href="{{ next.link|e }}" class="float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+      {% endif %}
+    </span>
+  </div>
   {%- block extrafooter %} {% endblock %}
-
 </footer>
-

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -323,8 +323,9 @@ html
     display: block
 footer
   color: $footer-color
-  p
-    margin-bottom: $base-line-height / 2
+  padding-bottom: 10px
+  hr
+    margin-bottom: 10px
   span.commit code
     padding: 0px
     font-family: $code-font-family
@@ -333,14 +334,28 @@ footer
     border: none
     color: $footer-color
 
-.rst-footer-buttons
-  &:before, &:after
-    width: 100%
-  +clearfix
+hr.marginbot
+  margin-top: 0
 
-.rst-breadcrumbs-buttons
-  margin-top: 12px
-  +clearfix
+hr.nomargin
+  margin: 0
+
+.contentinfo
+  text-align: center
+  display: flex
+  flex-direction: row
+
+.contentinfo-content
+  flex-grow: 1
+  p
+    margin-bottom: 0
+    font-size: 80%
+    line-height: $base-line-height * 3 / 4
+
+.prevnext
+  min-width: 80px
+  a
+    line-height: $base-line-height * 1.5
 
 #search-results
   .search li


### PR DESCRIPTION
In this PR, 'Previous' and 'Next' buttons' style is updated and they are moved to better fit the layout (header and footer). See comparison below:

![prevnext](https://user-images.githubusercontent.com/6628437/71750727-a016f100-2e79-11ea-9ba2-ca9ed97f4a82.gif)
