### PR TITLE
Fix canonical URLs with dirhtml builder

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -7,6 +7,15 @@
   {%- set titlesuffix = "" %}
 {%- endif %}
 {%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
+{%- if builder != "dirhtml" %}
+  {%- set canonical_page = pagename + ".html" %}
+{%- elif pagename == "index" %}
+  {%- set canonical_page = "" %}
+{%- elif pagename.endswith("/index") %}
+  {%- set canonical_page = pagename[:-("/index"|length)] + "/" %}
+{%- else %}
+  {%- set canonical_page = pagename + "/" %}
+{%- endif %}
 
 <!DOCTYPE html>
 <html lang="{{ lang_attr }}" >
@@ -24,7 +33,7 @@
   {% endif %}
   {# CANONICAL URL #}
   {% if theme_canonical_url %}
-    <link rel="canonical" href="{{ theme_canonical_url }}{{ pagename }}.html"/>
+    <link rel="canonical" href="{{ theme_canonical_url }}{{ canonical_page }}"/>
   {% endif %}
 
   {# JAVASCRIPTS #}


### PR DESCRIPTION
As suggested by @ericholscher in #285, using the logic from the
readthedocs-sphinx-ext package.

Currently if you set the `canonical_url` theme option (for example, to
`https://example.com/`), a canonical link like the following will be
generated for source files like `foo/bar.rst`:

```
<link rel="canonical" href="https://example.com/foo/bar.html"/>
```

This is good for the `html` builder, but doesn't match the output of the
`dirhtml` builder. This commit changes canonical link generation like
the above example to the following when the `dirhtml` builder is used:

```
<link rel="canonical" href="https://example.com/foo/bar/"/>
```

Canonical link generation remains the same as before when the `dirhtml`
builder is not used.