### PR TITLE
Mark the extension as safe for parallel reading and writing

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -28,3 +28,5 @@ def setup(app):
         # See http://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_message_catalog
         rtd_locale_path = path.join(path.abspath(path.dirname(__file__)), 'locale')
         app.add_message_catalog('sphinx', rtd_locale_path)
+
+    return {'parallel_read_safe': True, 'parallel_write_safe': True}


### PR DESCRIPTION
This allows projects that use this theme to enable parallel building of documentation.

See http://www.sphinx-doc.org/en/stable/extdev/#extension-metadata for more details.

Tested on the documentation of the BuildBot project which produces 10MB of identical HTML files in both parallel and sequencial sphinx modes.