### PR TITLE
Update 'Previous' and 'Next' buttons

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -69,14 +69,29 @@
   </ul>
 
   {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-  <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
-      {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
-      {% endif %}
-      {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
-      {% endif %}
+  <div class="rst-page-nav" role="navigation" aria-label="breadcrumb navigation">
+    <hr class="top" />
+    {% if next %}
+    <div class="nav-next">
+      <div class="nav-text">
+        {{ _('Next') }}<br />
+        <a href="{{ next.link|e }}" title="{{ next.title|striptags|e }}">{{ next.title|striptags|e }}</a>
+      </div>
+      <a class="nav-arrow" href="{{ next.link|e }}" title="{{ next.title|striptags|e }}" accesskey="n" rel="next"><span class="fa fa-angle-right"></span></a>
+    </div>
+    {% endif %}
+    {% if prev %}
+    <div class="nav-prev">
+      <a class="nav-arrow" href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-angle-left"></span></a>
+      <div class="nav-text">
+        {{ _('Previous') }}<br />
+        <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev">{{ prev.title|striptags|e }}</a>
+      </div>
+    </div>
+    {% endif %}
+    <hr class="bottom" />
   </div>
+  {% else %}
+  <hr />
   {% endif %}
-  <hr/>
 </div>

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -1,16 +1,30 @@
 <footer>
   {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
-    <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
+    <div class="rst-page-nav" role="navigation" aria-label="footer navigation">
+      <hr class="top" />
       {% if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
+      <div class="nav-next">
+        <div class="nav-text">
+          {{ _('Next') }}<br />
+          <a href="{{ next.link|e }}" title="{{ next.title|striptags|e }}">{{ next.title|striptags|e }}</a>
+        </div>
+        <a class="nav-arrow" href="{{ next.link|e }}" title="{{ next.title|striptags|e }}" accesskey="n" rel="next"><span class="fa fa-angle-right"></span></a>
+      </div>
       {% endif %}
       {% if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
+      <div class="nav-prev">
+        <a class="nav-arrow" href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-angle-left"></span></a>
+        <div class="nav-text">
+          {{ _('Previous') }}<br />
+          <a href="{{ prev.link|e }}" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev">{{ prev.title|striptags|e }}</a>
+        </div>
+      </div>
       {% endif %}
+      <hr class="bottom" />
     </div>
+    {% else %}
+    <hr />
   {% endif %}
-
-  <hr/>
 
   <div role="contentinfo">
     <p>

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -333,14 +333,38 @@ footer
     border: none
     color: $footer-color
 
-.rst-footer-buttons
-  &:before, &:after
-    width: 100%
-  +clearfix
-
-.rst-breadcrumbs-buttons
-  margin-top: 12px
-  +clearfix
+.rst-page-nav
+  font-size: .9em
+  a
+    color: #2980B9
+  hr.bottom
+    clear: both
+    margin-top: 0px
+  hr.top
+    clear: both
+    margin-bottom: 0px
+  .nav-prev
+    width: 50%
+    text-align: left
+    float: left
+    white-space: nowrap
+  .nav-next
+    width: 50%
+    text-align: right
+    float: right
+    white-space: nowrap
+  .nav-prev, .nav-next
+    .nav-text
+      display: inline-block
+      white-space: normal
+      padding: 10px 7px 8px 7px
+      vertical-align: top
+      max-width: 95%
+      a:hover
+        text-decoration: underline
+    .nav-arrow
+      font-size: 3em
+      display: inline-block
 
 #search-results
   .search li


### PR DESCRIPTION
This supersedes #865 after discussion with @eine.

I think showing the titles of the previous and next page makes users more likely to traverse forwards or backwards by giving them a preview of the content, thus improving usability and page views per session.

Tested with a **prev_next_buttons_location** of `top`, `bottom`, and `both`.