### PR TITLE
Proof of Concept: Hide search matches

### DIFF
--- a/sphinx_rtd_theme/searchbox.html
+++ b/sphinx_rtd_theme/searchbox.html
@@ -1,5 +1,5 @@
 {%- if builder != 'singlehtml' %}
-<div role="search">
+<div id="searchbox" role="search">
   <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
     <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
     <input type="hidden" name="check_keywords" value="yes" />


### PR DESCRIPTION
Unfortunately, the highlighting of search results has been removed in https://github.com/readthedocs/readthedocs.org/pull/6087.

I don't like this, and I think the real problem is that the RTD theme doesn't have a simple way to remove those highlights, like other Sphinx themes have, see #816.

This PR shows a *really simple* way to add this feature back to the theme.

Once we have this, we can revert the removal of the highlighting, see https://github.com/readthedocs/readthedocs.org/issues/6305.

I'm not interested in the styling (can somebody else please do that?), I just want to demonstrate a *very simple* way to get this functionality.

The relevant CSS selectors would probably be `#searchbox .highlight-link` for the `<p>` and `#searchbox a` (or `#searchbox p a`?) for the link itself.

I think it makes sense to add the "Hide Search Matches" link close to the search text field, but if desired, it could be placed anywhere be simply adding a `<div id="searchbox"></div>`. That's all there's to it.

Please note that this does *not* remove `?highlight=...` from the URL. Such a feature, if desired, should be implemented in Sphinx itself.

What do y'all think about this?