### PR TITLE
Fix font-size error for captions inside figures

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -23,6 +23,7 @@
     margin-bottom: $base-line-height
     p.caption
       font-style: italic
+      font-size: 100%
     p:last-child.caption
       margin-bottom: 0px
 


### PR DESCRIPTION
As was reported in #881 using the singlehtml builder the captions for figures was appearing with `font-size: 150%`. This happens because there is a extend `src/sass/_theme_rst.sass` that extends `h2` for captions in the toctree sidebar. Explicit defininiton of `font-size: 100%` in figures captions fix this.