### PR TITLE
Fix figures captions font-size using singlehtml builder

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -176,7 +176,7 @@
     // Do not override display:table for tables
     &:not(table)
       display: block
-  .toctree-wrapper p.caption
+  .toctree-wrapper > p.caption
     @extend h2
 
   // This is the #href that shows up on hover. Sphinx's is terrible so I hack it away.


### PR DESCRIPTION
As was reported in #881, using the singlehtml builder, the captions for figures appears with `font-size: 150%`. This happens because `.toctree-wrapper p.caption` definitions was inserted to style `.toctree-wrapper compound` divs titles at readthedocs index page, but the `h2` extend affects also to elements that are deeper in the DOM tree, like caption figures.

However, we can style only direct `p.caption` childs of `.toctree-wrapper` divs because these titles are not appearing at any other place (at least.

The pull request that I sent was not completely solving the problem, but this yes.