### PR TITLE
Fix bold error for 5th level toctree on first click.

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -152,6 +152,7 @@ function ThemeNav () {
                 link.closest('li.toctree-l2').addClass('current');
                 link.closest('li.toctree-l3').addClass('current');
                 link.closest('li.toctree-l4').addClass('current');
+                link.closest('li.toctree-l5').addClass('current');
                 link[0].scrollIntoView();
             }
         }


### PR DESCRIPTION
Before this pull, first clicks to 5th level toctree nav elements wasn't bolding them.

### BEFORE
![rtd-before](https://user-images.githubusercontent.com/23049315/78453873-d3ddfe80-7694-11ea-90c6-1eee183ad924.gif)

### AFTER
![rtd-after](https://user-images.githubusercontent.com/23049315/78453880-db9da300-7694-11ea-8694-a7d305ba79b3.gif)

