### PR TITLE
Add missing dot after copyright.

### DIFF
--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -18,10 +18,10 @@
       {%- if hasdoc('copyright') %}
         {% set path = pathto('copyright') %}
         {% set copyright = copyright|e %}
-        &copy; <a href="{{ path }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright }}
+        &copy; <a href="{{ path }}">{% trans %}Copyright{% endtrans %}</a> {{ copyright }}.
       {%- else %}
         {% set copyright = copyright|e %}
-        &copy; {% trans %}Copyright{% endtrans %} {{ copyright }}
+        &copy; {% trans %}Copyright{% endtrans %} {{ copyright }}.
       {%- endif %}
     {%- endif %}
 


### PR DESCRIPTION
The following stuff each has a dot at the end.