### PR TITLE
add view github link option

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -58,6 +58,8 @@
             {% else %}
               <a href="https://{{ gitlab_host|default("gitlab.com") }}/{{ gitlab_user }}/{{ gitlab_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ gitlab_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-gitlab"> {{ _('Edit on GitLab') }}</a>
             {% endif %}
+          {% elif display_github_url %}
+            <a href="{{ display_github_url }}" class="fa fa-github" target="_blank"> {{ _('View on GitHub') }}</a>
           {% elif show_source and source_url_prefix %}
             <a href="{{ source_url_prefix }}{{ pagename }}{{ suffix }}">{{ _('View page source') }}</a>
           {% elif show_source and has_source and sourcename %}


### PR DESCRIPTION
This commit contains a small change to allow you to set a link to a github repo to view.

html_context = {
    "display_github_url": 'https://github.com/<org>/<repo_name>',
}

Navigation would show "View on Github" with link.