### PR TITLE
Improve webpack dev server

### DIFF
--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -8,24 +8,29 @@ const common = require("./webpack.common.js");
 module.exports = merge(common, {
   mode: "development",
   watch: true,
+  // The dev server uses both contentBase and publicPath. The contentBase is
+  // used to server the built docs, and publicPath is the bundle path for live
+  // reloading. The publicPath intercepts requests to the static assets in
+  // _static/. Opening http://localhost:1919 is everything you need for
+  // development.
   devServer: {
-    contentBase: path.join(__dirname, "docs/build/html"),
-    watchContentBase: true,
-    compress: false,
+    contentBase: "docs/build/html",
     port: 1919,
+    open: false,
     hot: false,
     liveReload: true,
-    publicPath: "/_static/"
+    publicPath: "/_static/",
+    disableHostCheck: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*"
+    }
   },
   plugins: [
     new WatchPlugin({
       files: ["./docs/**/*.rst", "./docs/**/*.py"]
     }),
     new ShellPlugin({
-      onBuildEnd: ["make -C docs clean html"],
-      // dev=false here to force every build to trigger make, the default is
-      // first build only.
-      dev: false
+      onBuildStart: ["make -C docs clean html"],
     })
   ]
 });


### PR DESCRIPTION
This no longer continually rebuilds the docs to test the JS/CSS. Instead, it
uses webpacks nice live reload feature for bundle assets. Through use of both a
contentBase and a publicPath option, we can serve `docs/build/html` content, but
requests to `docs/build/html/_static/` will be intercepted by webpack and return
the live reload bundles.