### PR TITLE
Change FOUT back to FOIT

### DIFF
--- a/src/sass/_theme_variables.sass
+++ b/src/sass/_theme_variables.sass
@@ -66,4 +66,4 @@ $custom-font-family:                  "Roboto Slab", "ff-tisa-web-pro", "Georgia
 $custom-font-family2:                 Georgia, serif
 $code-font-family:                    SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace
 
-$font-display:                        swap
+$font-display:                        block


### PR DESCRIPTION
The fonts loaded in 0.4.3 did not have a configuration for the CSS
`font-display`, and they were switched to `font-display: swap` in
0.5.0rc1. The old behavior was FOIT, and `swap` changed the behavior to
FOUT, which was more noticeable. This changes back to a long block
period while the fonts are loading.

For more information on the FOUT/FOIT and the font-display mechanism:
https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display

Fixes #913