### PR TITLE
Add local TOC as right sidebar for #764

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -193,6 +193,12 @@
           <div role="main" class="document" itemscope="itemscope" itemtype="http://schema.org/Article">
           {%- block document %}
            <div itemprop="articleBody">
+            {% if toc|length > title|length + 75 %}
+            <nav id="local-table-of-contents" role="navigation" aria-labelledby="local-table-of-contents-title">
+              <h4 id="local-table-of-contents-title">On This Page</h4>
+              {{ toc }}
+            </nav>
+            {% endif %}
             {% block body %}{% endblock %}
            </div>
            {% if self.comments()|trim %}

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -360,6 +360,68 @@ footer
   margin-top: 12px
   +clearfix
 
+#local-table-of-contents
+  padding-bottom: 20px
+  #local-table-of-contents-title
+    margin-bottom: 10px
+  a[href="#"]
+    display: none
+  & > ul
+    & > li
+      list-style: none
+      margin-top: 0
+  li
+    list-style: square
+    margin-bottom: 5px
+    margin-top: 5px
+  ul
+    ul
+      padding-left: 0
+      margin-left: 20px
+      padding-right: 0
+
+@media screen and (min-width: $nav-media-query + $local-toc-width)
+  #local-table-of-contents
+    display: block
+    position: fixed
+    margin-left: 0
+    overflow-y: auto
+    height: 95%
+    top: 45px
+    left: 1100px
+    width: $local-toc-width
+    #local-table-of-contents-title
+      display: block
+      font-size: 16px
+      width: 100%
+      padding-left: 10px
+      padding-top: 10px
+      padding-bottom: 5px
+      margin-bottom: -5px
+      border-left: 7px solid darken($local-toc-border-color, 20%)
+    ul
+      list-style: none
+    & > ul
+      border-left: 7px solid darken($local-toc-border-color, 20%)
+      padding-bottom: 10px
+    ul
+      &:first-of-type
+        padding-left: 0
+        margin-left: 0
+    li
+      margin-top: 5px
+      margin-bottom: 5px
+      margin-left: 20px
+    & > ul
+      & > li
+        margin-left: 10px
+    ul
+      ul
+        padding-left: 0
+        margin-left: 10px
+        padding-right: 0
+        margin-right: 10px
+
 #search-results
   .search li
     margin-bottom: $base-line-height

--- a/src/sass/_theme_variables.sass
+++ b/src/sass/_theme_variables.sass
@@ -53,6 +53,10 @@ $nav-link-color-hover:                lighten($nav-link-color, 6%) !default
 $nav-link-color-alt:                  hsl(33, 100%, 51%)
 $nav-caption:                         lighten($blue, 15%)
 
+//Local TOC colors
+$local-toc-border-color:              $section-background-color
+$local-toc-width:                     325px
+
 // Sidebar colors
 $sidebar-background-color:            $table-stripe-color
 $sidebar-border-color:                $table-border-color


### PR DESCRIPTION
This PR adds a table of contents for the local headings on the page (excluding the page title) as a right sidebar, as mentioned in #764. This implementation is similar to the one in [GitLab's Handbook](https://about.gitlab.com/handbook/) in that is moves the local TOC to the top of the page on smaller screens.

Demo:

![local-toc-sphinx-rtd-theme](https://user-images.githubusercontent.com/3474095/81355467-79fd9980-9083-11ea-99e9-59a9ea2d3942.gif)
