### PR TITLE
fix list style on nested lists

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -141,9 +141,9 @@
       border-color: rgba(0,0,0,.1) !important
   .section ul, .toctree-wrapper ul
     @extend .wy-plain-list-disc
-  .section ol.loweralpha, .section ol.loweralpha li
+  .section ol.loweralpha, .section ol.loweralpha > li
     list-style: lower-alpha
-  .section ol.upperalpha, .section ol.upperalpha li
+  .section ol.upperalpha, .section ol.upperalpha > li
     list-style: upper-alpha
   .section ol, ol.arabic
     @extend .wy-plain-list-decimal


### PR DESCRIPTION
When I use an alpha list style like this:

```
a) Foo
b) Bar

   - asd
   - asd
```

I expect the outer list to use `list-style: lower-alpha` and the inner list to use `list-style: disc`. Instead, both lists use the former.