### PR TITLE
Add colon after field list terms

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -269,6 +269,8 @@
       grid-template-columns: max-content auto
       > dt
         padding-left: 1rem
+        &:after
+          content: ":"
       > dt, > dd
         margin-bottom: 0rem
     dl.footnote


### PR DESCRIPTION
Currently, python method parameter/etc field lists are the same class as
general field lists, so we can't treat them differently. This reverts
styling the field list without the colon for now, and is comparable to
how the HTML 4 writer outputs field/parameter lists.

Refs #920