### PR TITLE
Revert "Add more localized strings" because <a alt> is invalid

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -118,7 +118,7 @@
           {% if logo and theme_logo_only %}
             <a href="{{ pathto(master_doc) }}">
           {% else %}
-            <a href="{{ pathto(master_doc) }}" class="icon icon-home" alt="{{ _("Documentation Home") }}"> {{ project }}
+            <a href="{{ pathto(master_doc) }}" class="icon icon-home"> {{ project }}
           {% endif %}
 
           {% if logo %}


### PR DESCRIPTION
The `alt` attribute is only valid on the `<area>`, `<img>`, and `<input>` elements, not `<a>`.

https://html.spec.whatwg.org/multipage/indices.html#attributes-3:attr-area-alt

This reverts commit 8f327360a5ed338341153e526aafce642a2846bd (#806).