### PR TITLE
Work around Firefox list marker positioning issue

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -88,7 +88,6 @@
     margin: 0
     padding: ($base-line-height / 2) ($base-line-height / 2)
     display: block
-    overflow: auto
     & .hll
       // Line emphasis spans full width
       display: block


### PR DESCRIPTION
Firefox displayed list markers too low when the first element in a list
element is a literal block. Removing the overflow property from the
pre element works around this. The overflow property seems to be
redundant, as the highlight div wrapping the pre also has overflow-x
set to display a scroll bar when necessary, and overflow-y doesn't seem to
have any use here.

I'm not quite sure what is going on here, but I have not found a reason why
this overflow property exists, so I'm proposing to remove it. There is a similar
property on the `pre.literal-block` selector, but I haven't found out what the
`literal-block` class is used for at all, so I didn't touch it.

Before:
![before](https://user-images.githubusercontent.com/419139/87974077-c9bc0080-cac9-11ea-90fe-ff6ecb290db1.png)

After:
![after](https://user-images.githubusercontent.com/419139/87974092-cfb1e180-cac9-11ea-81fb-b9721cf64b00.png)
