### PR TITLE
Ignore prev/next nav buttons using meta fields

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -180,6 +180,11 @@ The following options can be used as :ref:`file-wide metadata
 
     Force the :guilabel:`Edit on GitLab` button to use the configured URL.
 
+.. confval:: ignorenav
+
+    Acceptable values are ``prev``, ``next``, and ``both``. ``prev`` will
+    override/ignore the previous nav buttons, similar applies to ``next``, and
+    ``both`` will ignore both previous and next buttons.
 
 Other configuration
 ===================

--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -70,12 +70,15 @@
     {% endblock %}
   </ul>
 
-  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+  {%- if meta is defined and meta is not none and 'ignorenav' in meta %}
+      {%- set ignorenav = meta.get('ignorenav') %}
+  {%- endif %}
+  {% if (theme_prev_next_buttons_location == 'top' or theme_prev_next_buttons_location == 'both') and (next or prev) and ignorenav != 'both' %}
   <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="breadcrumb navigation">
-      {% if next %}
+      {% if next and ignorenav != 'next' %}
         <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
       {% endif %}
-      {% if prev %}
+      {% if prev and ignorenav != 'prev' %}
         <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
       {% endif %}
   </div>

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -1,10 +1,13 @@
 <footer>
-  {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
+  {%- if meta is defined and meta is not none and 'ignorenav' in meta %}
+      {%- set ignorenav = meta.get('ignorenav') %}
+  {%- endif %}
+  {% if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) and ignorenav != 'both' %}
     <div class="rst-footer-buttons" role="navigation" aria-label="footer navigation">
-      {% if next %}
+      {% if next and ignorenav != 'next' %}
         <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right"></span></a>
       {% endif %}
-      {% if prev %}
+      {% if prev and ignorenav != 'prev' %}
         <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left"></span> {{ _('Previous') }}</a>
       {% endif %}
     </div>


### PR DESCRIPTION
I've found sometimes the content that follows or precedes in the toctree isn't directly relevant and the nav buttons need to be ignored or sometimes you want to not show any nav for specific page for a landing page type feel. This may not be the best approach, but it can at least serve as a proof of concept.

To use, add the `:ignorenav:` meta field to the top of the desired page(s). Accepted values are `prev`, `next`, and `both`. `prev` will override/ignore the previous nav button, same applies to `next`, and `both` will ignore both buttons.