### PR TITLE
Use just python3 in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,5 @@
 version: 2
 python:
-  version: 3.6
+  version: 3
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
Tested this to work on a local RTD server with Python 3.7. Consider this as a better default than pinning specific Python 3 versions, which makes it harder for the central RTD server to get rid of these versions.