### PR TITLE
html search: Do not load language_data.js in non-search pages

### DIFF
--- a/sphinx_rtd_theme/search.html
+++ b/sphinx_rtd_theme/search.html
@@ -13,6 +13,7 @@
 {%- block scripts %}
     {{ super() }}
     <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block footer %}
   <script type="text/javascript">


### PR DESCRIPTION
This is needed with changes in sphinx 3.4.x.

See https://github.com/sphinx-doc/sphinx/commit/f5289bb69993d2b1f83a509f56e418fcd5d00b87