### PR TITLE
Match searchbox from upstream

### DIFF
--- a/sphinx_rtd_theme/searchbox.html
+++ b/sphinx_rtd_theme/searchbox.html
@@ -1,9 +1,0 @@
-{%- if 'singlehtml' not in builder %}
-<div role="search">
-  <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
-    <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
-    <input type="hidden" name="check_keywords" value="yes" />
-    <input type="hidden" name="area" value="default" />
-  </form>
-</div>
-{%- endif %}


### PR DESCRIPTION
This has been since 1.x

https://github.com/sphinx-doc/sphinx/blob/v1.5/sphinx/themes/basic/searchbox.html

The latest version includes some nice things like js enabled detection
and aria labels :)

~I don't see anything special we are doing to make this custom.~

Ah, looks like we remove the "Go" button


![Screenshot_2020-12-03 Read the Docs Sphinx Theme — Read the Docs Sphinx Theme 0 5 0 documentation](https://user-images.githubusercontent.com/4975310/101096216-3fae9900-358d-11eb-8f4b-2345ab71a894.png)
