### PR TITLE
sphinx_rtd_theme/layout: Set url_root properly on index, don't use '#'

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -57,7 +57,7 @@
   {%- if not embedded %}
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
     {% if sphinx_version >= "1.8.0" %}
-      <script type="text/javascript" id="documentation_options" data-url_root="{{ pathto('', 1) }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+      <script type="text/javascript" id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
       {%- for scriptfile in script_files %}
         {{ js_tag(scriptfile) }}
       {%- endfor %}


### PR DESCRIPTION
- You can see a practical demonstration of the problem, fully seeing
  the effect if it is not fixed, here (though that example uses the
  alabaster theme, the effect is the same here):
  https://github.com/executablebooks/sphinx-copybutton/issues/110
- This is a copy of a fix from Sphinx.  The sphinx pull request is
  https://github.com/sphinx-doc/sphinx/pull/8524

Detailed description:

- url_root is set to `#` on the index page, which layout.html tries to
  change back to `''` (the empty string).
- But, this updated url_root wasn't used in the actual location, as an
  argument to `documentation_options.js`.
- Thus, clever enough templates, which tried to use
  `$DOCUMENTATION_OPTIONS.URL_ROOT` inside javascript would fail.
  This was manifested as broken links, which led to this issue:
  https://github.com/executablebooks/sphinx-copybutton/issues/110
- I have eventually traced that back to sphinx itself, and found that
  layout.html tried to fix the problem, but the fixed value wasn't
  used.
- This fix works in my basic test, but I will continue with more tests.
- Review:
  - someone more clever should examine this and make sure it makes
    sense
  - This does not have tests.  Should it?