### PR TITLE
Fix Nav Buttons Size

### DIFF
--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -70,8 +70,7 @@ html
       margin-left: -1.2em
       @extend .fa
       @extend .fa-plus-square-o
-      font-size: .8em
-      line-height: 1.6em
+      line-height: 18px
       color: darken($menu-link-medium, 20%)
 
   // On state for the first level
@@ -92,8 +91,7 @@ html
       @extend .fa
       @extend .fa-minus-square-o
       display: block
-      font-size: .8em
-      line-height: 1.6em
+      line-height: 18px
       color: darken($menu-link-medium, 30%)
 
   li.toctree-l1.current > a

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -27,12 +27,6 @@ html
     line-height: $base-font-size * 2
     padding: 0 $base-font-size
 
-%menu-vertical-btn
-  @extend .fa
-  @extend .fa-plus-square-o
-  display: block
-  line-height: 18px
-
 .wy-menu-vertical
   width: $nav-desktop-width
 
@@ -71,9 +65,13 @@ html
       padding-right: 0
     // Expand links
     span.toctree-expand
-      @extend %menu-vertical-btn
+      display: block
       float: left
       margin-left: -1.2em
+      @extend .fa
+      @extend .fa-plus-square-o
+      font-size: .8em
+      line-height: 1.6em
       color: darken($menu-link-medium, 20%)
 
   // On state for the first level
@@ -91,6 +89,11 @@ html
       span.toctree-expand
         color: $menu-link-medium
     span.toctree-expand
+      @extend .fa
+      @extend .fa-minus-square-o
+      display: block
+      font-size: .8em
+      line-height: 1.6em
       color: darken($menu-link-medium, 30%)
 
   li.toctree-l1.current > a

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -27,6 +27,12 @@ html
     line-height: $base-font-size * 2
     padding: 0 $base-font-size
 
+%menu-vertical-btn
+  @extend .fa
+  @extend .fa-plus-square-o
+  display: block
+  line-height: 18px
+
 .wy-menu-vertical
   width: $nav-desktop-width
 
@@ -65,13 +71,9 @@ html
       padding-right: 0
     // Expand links
     span.toctree-expand
-      display: block
+      @extend %menu-vertical-btn
       float: left
       margin-left: -1.2em
-      @extend .fa
-      @extend .fa-plus-square-o
-      font-size: .8em
-      line-height: 1.6em
       color: darken($menu-link-medium, 20%)
 
   // On state for the first level
@@ -89,11 +91,6 @@ html
       span.toctree-expand
         color: $menu-link-medium
     span.toctree-expand
-      @extend .fa
-      @extend .fa-minus-square-o
-      display: block
-      font-size: .8em
-      line-height: 1.6em
       color: darken($menu-link-medium, 30%)
 
   li.toctree-l1.current > a


### PR DESCRIPTION
Currently Nav buttons to expand the menu are a bit small and do not match the link text. This makes the buttons match the size of the link text and deduplicates some of the style rules.

Before:
![image](https://user-images.githubusercontent.com/15183467/109872809-ed881d00-7c3a-11eb-9906-db5fff19d485.png)

After:
![image](https://user-images.githubusercontent.com/15183467/109872726-d0ebe500-7c3a-11eb-9e4c-113e621b36f7.png)
