### PR TITLE
Nav: Fix right padding on level2+

### DIFF
--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -135,6 +135,7 @@ html
           li.toctree-l#{$toc_level + 1}  > a
             @extend %display_current_toctree_element
             padding: $gutter / 4 $gutter * ($toc_level + .5)
+            padding-right: $gutter
         a:hover span.toctree-expand
           @extend %toctree_hover_link_color
     @if $toc_level > 2 and $toc_level < 5


### PR DESCRIPTION
The sets the right padding the same as the first level.
The current padding is too large and varies between toc levels.
Now, the right padding is the same between all levels and only the left padding changes

Before:
![image](https://user-images.githubusercontent.com/15183467/109898093-a9f4d980-7c61-11eb-9182-76fae68191d0.png)

After:
![image](https://user-images.githubusercontent.com/15183467/109897941-72862d00-7c61-11eb-8076-ff11c8aa32a7.png)
