### PR TITLE
Tests: Remove test for sphinx version no longer supported

### DIFF
--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -63,31 +63,14 @@ def test_empty():
     for (app, status, warning) in build_all('test-empty'):
         assert app.env.get_doctree('index').traverse(addnodes.toctree)
         content = open(os.path.join(app.outdir, 'index.html')).read()
-        if sphinx.version_info < (1, 4):
-            if isinstance(app.builder, SingleFileHTMLBuilder):
-                assert '<div class="toctree-wrapper compound">\n</div>' in content
-                assert '<div class="local-toc">' in content
-            else:
-                global_toc = (
-                    '<div class="toctree-wrapper compound">\n'
-                    '<ul class="simple">\n</ul>\n'
-                    '</div>'
-                )
-                local_toc = (
-                    '<div class="local-toc"><ul class="simple">'
-                    '</ul>\n</div>'
-                )
-                assert global_toc in content
-                assert local_toc not in content
-        else:
-            global_toc = '<div class="toctree-wrapper compound">\n</div>'
-            local_toc = (
-                '<div class="local-toc"><ul>\n'
-                '<li><a class="reference internal" href="#">test-empty</a></li>'
-                '</ul>\n</div>'
-            )
-            assert global_toc in content
-            assert local_toc not in content
+        global_toc = '<div class="toctree-wrapper compound">\n</div>'
+        local_toc = (
+            '<div class="local-toc"><ul>\n'
+            '<li><a class="reference internal" href="#">test-empty</a></li>'
+            '</ul>\n</div>'
+        )
+        assert global_toc in content
+        assert local_toc not in content
 
 
 def test_missing_toctree():


### PR DESCRIPTION
We no longer run tests against sphinx 1.4 so this can be removed.