### PR TITLE
Deprecate html4_writer

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -33,6 +33,8 @@ def config_initiated(app, config):
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
     app.require_sphinx('2.0')
+    if app.config.html4_writer:
+        logger.warning("'html4_writer' is not compatible with sphinx_rtd_theme")
     # Register the theme that can be referenced without adding a theme path
     app.add_html_theme('sphinx_rtd_theme', path.abspath(path.dirname(__file__)))
 


### PR DESCRIPTION
This does not remove the fixes that we made for the html4_writer, these could be removed in a future release.

Depends on #1075
Fixes #938
