### PR TITLE
npm: Add a few missing package fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx_rtd_theme",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx_rtd_theme",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
     "build": "webpack --config webpack.prod.js",
     "preinstall": "bin/preinstall.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/readthedocs/sphinx_rtd_theme.git"
+  },
+  "author": "Read the Docs",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/readthedocs/sphinx_rtd_theme/issues"
+  },
+  "homepage": "https://github.com/readthedocs/sphinx_rtd_theme",
   "dependencies": {},
   "devDependencies": {
     "bourbon": "~4.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphinx_rtd_theme",
   "main": "js/theme.js",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphinx_rtd_theme",
   "main": "js/theme.js",
-  "version": "0.5.2",
+  "version": "0.5.1",
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",


### PR DESCRIPTION
This fixes these warnings when running `npm install`:

```
npm WARN sphinx_rtd_theme@0.5.1 No repository field.
npm WARN sphinx_rtd_theme@0.5.1 No license field.
```