### PR TITLE
Tests: Run against nav toctree and not builtin toctree

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -160,7 +160,7 @@
                                       includehidden=theme_includehidden|tobool,
                                       titles_only=theme_titles_only|tobool) %}
             {%- if toctree %}
-              {{ toctree }}
+              {{- toctree }}
             {%- else %}
               <!-- Local TOC -->
               <div class="local-toc">{{ toc }}</div>

--- a/tests/roots/test-basic/conf.py
+++ b/tests/roots/test-basic/conf.py
@@ -2,3 +2,8 @@
 
 master_doc = 'index'
 exclude_patterns = ['_build']
+
+html_theme_options = {
+    'collapse_navigation': False,
+    'navigation_depth': -1,
+}

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -15,7 +15,7 @@ def test_basic():
 
         if isinstance(app.builder, DirectoryHTMLBuilder):
             search = (
-                '<div class="toctree-wrapper compound">\n'
+                '<div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Main">'
                 '<ul>\n'
                 '<li class="toctree-l1">'
                 '<a class="reference internal" href="foo/">foo</a>'
@@ -25,21 +25,25 @@ def test_basic():
                 '</ul>\n'
                 '</li>\n'
                 '</ul>\n'
-                '</div>'
             )
             assert search in content
         elif isinstance(app.builder, SingleFileHTMLBuilder):
             search = (
+                '<div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Main">'
                 '<ul>\n'
                 '<li class="toctree-l1">'
                 '<a class="reference internal" href="index.html#document-foo">foo</a>'
+                '<ul>\n'
+                '<li class="toctree-l2">'
+                '<a class="reference internal" href="index.html#document-bar">bar</a></li>\n'
+                '</ul>\n'
                 '</li>\n'
-                '</ul>'
+                '</ul>\n'
             )
             assert search in content
         else:
             search = (
-                '<div class="toctree-wrapper compound">\n'
+                '<div class="wy-menu wy-menu-vertical" data-spy="affix" role="navigation" aria-label="Main">'
                 '<ul>\n'
                 '<li class="toctree-l1">'
                 '<a class="reference internal" href="foo.html">foo</a>'
@@ -49,7 +53,6 @@ def test_basic():
                 '</ul>\n'
                 '</li>\n'
                 '</ul>\n'
-                '</div>'
             )
             assert search in content, ('Missing search with builder {0}'
                                        .format(app.builder.name))


### PR DESCRIPTION
Before, the test were checking the `.. toctree::` directive and not the navigation toctree in our template. This is now fixed.

A white space change was made so we dont have to include the white space in the search string.

The test project was update to not collapse the navigation and to use infinite toc depth to match the old test case.