### PR TITLE
Docs: Always use local theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,21 +4,9 @@ import sys
 import os
 import re
 
-# If we are building locally, or the build on Read the Docs looks like a PR
-# build, prefer to use the version of the theme in this repo, not the installed
-# version of the theme.
-def is_development_build():
-    # PR builds have an interger version
-    re_version = re.compile(r'^[\d]+$')
-    if 'READTHEDOCS' in os.environ:
-        version = os.environ.get('READTHEDOCS_VERSION', '')
-        if re_version.match(version):
-            return True
-        return False
-    return True
-
-if is_development_build():
-    sys.path.insert(0, os.path.abspath('..'))
+# Prefer to use the version of the theme in this repo
+# and not the installed version of the theme.
+sys.path.insert(0, os.path.abspath('..'))
 sys.path.append(os.path.abspath('./demo/'))
 
 import sphinx_rtd_theme


### PR DESCRIPTION
This changes non PR builds on rtd to use the local theme and not the old 0.4.3 theme. We want our docs to show what the theme looks like based on the current release, not an old version.