### PR TITLE
Fix code includes style

### DIFF
--- a/docs/demo/demo.rst
+++ b/docs/demo/demo.rst
@@ -154,11 +154,21 @@ Python-specific usage examples; begun with ">>>"
 Code Blocks
 -----------
 
+.. rubric:: ``include``
+
+.. include:: test_py_module/test.py
+  :code: python
+  :number-lines:
+  :end-line: 10
+
+.. rubric:: ``parsed-literal``
+
 .. parsed-literal::
 
     # parsed-literal test
     curl -O http://someurl/release-|version|.tar-gz
 
+.. rubric:: ``code-block``
 
 .. code-block:: json
     :caption: Code Blocks can have captions.

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -364,23 +364,31 @@
     .field-body
       text-align: left
 
-  // These are the "literals" that get spit out when you mark stuff as ``code`` as your write.
+  // These are generic code blocks from includes
   tt, code
-    @extend code
+    display: block
+    border: none
+    padding: 0px
+    background: inherit
+    font-size: unset
+    white-space: pre
     color: $black
-    font-family: $code-font-family
-    padding: 2px 5px
     big, em
-      font-size: 100% !important
       line-height: normal
+      font-size: 100% !important
 
+    // These are the "literals" that get spit out when you mark stuff as ``code`` as your write.
     &.literal
-      color: $text-code-color
+      display: inline
+      border: 1px solid $table-border-color
+      padding: 2px 5px
+      font-size: 75%
       white-space: normal
+      color: $text-code-color
     &.xref, a &
       font-weight: bold
       color: $text-codexref-color
-  pre, kbd, samp
+  pre, kbd, samp, code
     font-family: $code-font-family
   // If the literal is inside an a tag, let's color it like a link
   a tt, a code


### PR DESCRIPTION
Currently this is inheriting a lot of rules from wyrm that dont apply here.
To fix this some wyrm rules are manually overriden or copied.

With all the fixes made in the theme or work around wyrm issues we will want to carefully see what can be removed when we move to bootstrap.

Fixes #930