### PR TITLE
Require Sphinx 1.6 deprecate html4

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -45,3 +45,11 @@ Symlink or subtree the ``sphinx_rtd_theme/sphinx_rtd_theme`` repository into you
 
     html_theme = "sphinx_rtd_theme"
     html_theme_path = ["_themes", ]
+
+Compatibility
+=============
+
+``sphinx_rtd_theme`` depends on at least Sphinx 1.6 although,
+we recommend at least Sphinx 2 to take advantage of the html5 writer.
+The html4 writer is still supported however,
+it is deprecated and support will be removed in the near future.

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         ]
     },
     install_requires=[
-        'sphinx'
+        'sphinx>=1.6'
     ],
     tests_require=[
         'pytest',

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -8,12 +8,7 @@ from os import path
 
 from sphinx import version_info
 from sphinx.locale import _
-
-try:
-    # Avaliable from Sphinx 1.6
-    from sphinx.util.logging import getLogger
-except ImportError:
-    from logging import getLogger
+from sphinx.util.logging import getLogger
 
 
 __version__ = '0.5.1'
@@ -38,9 +33,16 @@ def config_initiated(app, config):
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
-    if version_info >= (1, 6, 0):
-        # Register the theme that can be referenced without adding a theme path
-        app.add_html_theme('sphinx_rtd_theme', path.abspath(path.dirname(__file__)))
+    app.require_sphinx('1.6')
+    if version_info <= (2, 0, 0):
+        if not app.config.html_experimental_html5_writer:
+            logger.warning("'html4_writer' is deprecated with sphinx_rtd_theme")
+    else:
+        if app.config.html4_writer:
+            logger.warning("'html4_writer' is deprecated with sphinx_rtd_theme")
+
+    # Register the theme that can be referenced without adding a theme path
+    app.add_html_theme('sphinx_rtd_theme', path.abspath(path.dirname(__file__)))
 
     if version_info >= (1, 8, 0):
         # Add Sphinx message catalog for newer versions of Sphinx


### PR DESCRIPTION
Sphinx 1.6 is required for de76c03824cc7396fa882cca2d35f4a2f2a3ede2 we also do not test against versions lower than 1.6 so we should safely drop it.

This is similar to #1076 and #1075 but less strict

With default settings, no one should see warnings with sphinx >= 2. Warnings are printed if using html4_writer or not using experimental html5 (removed in sphinx2).

Fixes #938