### PR TITLE
Tests: Fix deprecation warning with new sphinx versions

### DIFF
--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3,8 +3,8 @@ import os
 import pytest
 import sphinx
 from sphinx import addnodes
-import sphinx.builders.dirhtml.DirectoryHTMLBuilder
-import sphinx.builders.singlehtml.SingleFileHTMLBuilder
+from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+from sphinx.builders.singlehtml import SingleFileHTMLBuilder
 
 from .util import build_all
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3,8 +3,15 @@ import os
 import pytest
 import sphinx
 from sphinx import addnodes
-from sphinx.builders.dirhtml import DirectoryHTMLBuilder
-from sphinx.builders.singlehtml import SingleFileHTMLBuilder
+try:
+    # Available from Sphinx 2.0
+    from sphinx.builders.dirhtml import DirectoryHTMLBuilder
+    from sphinx.builders.singlehtml import SingleFileHTMLBuilder
+except ImportError:
+    from sphinx.builders.html import (
+        DirectoryHTMLBuilder,
+        SingleFileHTMLBuilder,
+    )
 
 from .util import build_all
 

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3,7 +3,8 @@ import os
 import pytest
 import sphinx
 from sphinx import addnodes
-from sphinx.builders.html import SingleFileHTMLBuilder, DirectoryHTMLBuilder
+import sphinx.builders.dirhtml.DirectoryHTMLBuilder
+import sphinx.builders.singlehtml.SingleFileHTMLBuilder
 
 from .util import build_all
 


### PR DESCRIPTION
These builders were split in sphinx and the old import path will be removed in the upcoming Sphinx 4 release.
