### PR TITLE
Cleanup: Remove workaround/compatibility for old 0.3 version

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -18,14 +18,6 @@ function ThemeNav () {
     nav.enable = function (withStickyNav) {
         var self = this;
 
-        // TODO this can likely be removed once the theme javascript is broken
-        // out from the RTD assets. This just ensures old projects that are
-        // calling `enable()` get the sticky menu on by default. All other cals
-        // to `enable` should include an argument for enabling the sticky menu.
-        if (typeof(withStickyNav) == 'undefined') {
-            withStickyNav = true;
-        }
-
         if (self.isRunning) {
             // Only allow enabling nav logic once
             return;
@@ -61,12 +53,6 @@ function ThemeNav () {
             self.onResize();
         });
 
-    };
-
-    // TODO remove this with a split in theme and Read the Docs JS logic as
-    // well, it's only here to support 0.3.0 installs of our theme.
-    nav.enableSticky = function() {
-        this.enable(true);
     };
 
     nav.init = function ($) {
@@ -205,10 +191,6 @@ module.exports.ThemeNav = ThemeNav();
 if (typeof(window) != 'undefined') {
     window.SphinxRtdTheme = {
         Navigation: module.exports.ThemeNav,
-        // TODO remove this once static assets are split up between the theme
-        // and Read the Docs. For now, this patches 0.3.0 to be backwards
-        // compatible with a pre-0.3.0 layout.html
-        StickyNav: module.exports.ThemeNav,
     };
 }
 


### PR DESCRIPTION
This should now be safe to remove. I tested locally and sticky nav work both on and off.

I am not sure about the rtd side if this cases issues.