### PR TITLE
Docs: Fix intersphinx_mapping

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ pygments_style = 'default'
 
 intersphinx_mapping = {
     'rtd': ('https://docs.readthedocs.io/en/stable/', None),
-    'sphinx': ('https://www.sphinx-doc.org/en/stable/', None),
+    'sphinx': ('https://www.sphinx-doc.org/en/master/', None),
 }
 
 html_theme = 'sphinx_rtd_theme'


### PR DESCRIPTION
Sphinx documentation has moved from https://www.sphinx-doc.org/en/stable/ to https://www.sphinx-doc.org/en/master/

Fixes the command line message:
```
intersphinx inventory has moved: https://www.sphinx-doc.org/en/stable/objects.inv -> https://www.sphinx-doc.org/en/master/objects.inv
```