### PR TITLE
Setup: Require docutils<0.17'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,8 @@ setup(
         ]
     },
     install_requires=[
-        'sphinx>=1.6'
+        'sphinx>=1.6',
+        'docutils<0.17', # https://github.com/sphinx-doc/sphinx/issues/9001
     ],
     tests_require=[
         'pytest',


### PR DESCRIPTION
Docutils 0.17 changes the html output for some markup, until support is added to properly style this new markup we should pin to use an older version.

It may not be a bad idea to keep a pinned version in the theme to prevent this issue in the future.

Fixes #1112

If possible this should be committed into its own 0.5.2 release ASAP!