### PR TITLE
Fix backport of requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         ]
     },
     install_requires=[
-        'sphinx>=1.6'
+        'sphinx>=1.6',
         'docutils<0.17', # https://github.com/sphinx-doc/sphinx/issues/9001
     ],
     tests_require=[


### PR DESCRIPTION
This was fixed before releasing 0.5.2,
but looks like the change was lost after merging it to master.

ref https://github.com/readthedocs/sphinx_rtd_theme/issues/1115#issuecomment-814376813