### PR TITLE
Align top and side navigation background colors on mobile

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -174,7 +174,7 @@
     <section data-toggle="wy-nav-shift" class="wy-nav-content-wrap">
 
       {#- MOBILE NAV, TRIGGLES SIDE NAV ON TOGGLE #}
-      <nav class="wy-nav-top" aria-label="{{ _('Top') }}">
+      <nav class="wy-nav-top" aria-label="{{ _('Top') }}" {% if theme_style_nav_header_background %} style="background: {{theme_style_nav_header_background}}" {% endif %}>
         {%- block mobile_nav %}
           <i data-toggle="wy-nav-top" class="fa fa-bars"></i>
           <a href="{{ pathto(master_doc) }}">{{ project }}</a>


### PR DESCRIPTION
Hello!

This PR aligns top and side navigation background colors on mobile when configured with `style_nav_header_background` in `conf.py`. Currently only the background of the side navigation header is affected by the configuration, but it would be great if the top navigation bar in mobile phones was affected as well.

Configuration:
```python
html_theme_options = {
    'style_nav_header_background': '#7289da'
}
```

Before this PR:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/176810/115136460-427fc700-a020-11eb-97aa-5603d6161351.png">
<img width="403" alt="image" src="https://user-images.githubusercontent.com/176810/115136474-4dd2f280-a020-11eb-83b1-8f5b66e0e53c.png">

After this PR:
<img width="403" alt="image" src="https://user-images.githubusercontent.com/176810/115136486-63481c80-a020-11eb-94a1-ce3f37c9d483.png">
<img width="403" alt="image" src="https://user-images.githubusercontent.com/176810/115136495-6cd18480-a020-11eb-8698-423d6ccdb605.png">

Thanks!