### PR TITLE
Include aria-label in search box

### DIFF
--- a/sphinx_rtd_theme/searchbox.html
+++ b/sphinx_rtd_theme/searchbox.html
@@ -1,7 +1,7 @@
 {%- if 'singlehtml' not in builder %}
 <div role="search">
   <form id="rtd-search-form" class="wy-form" action="{{ pathto('search') }}" method="get">
-    <input type="text" name="q" placeholder="{{ _('Search docs') }}" />
+    <input type="text" name="q" aria-label="{{ _('Search docs') }}" placeholder="{{ _('Search docs') }}" />
     <input type="hidden" name="check_keywords" value="yes" />
     <input type="hidden" name="area" value="default" />
   </form>


### PR DESCRIPTION
Screen readers use aria-label.

Fixes part of https://github.com/readthedocs/sphinx_rtd_theme/issues/970