### PR TITLE
Remove discouraged type="text/javascript" from scripts

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -57,12 +57,12 @@
   {%- if not embedded %}
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
     {%- if sphinx_version >= "1.8.0" -%}
-      <script type="text/javascript" id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
+      <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
       {%- for scriptfile in script_files %}
         {{ js_tag(scriptfile) }}
       {%- endfor %}
     {%- else %}
-      <script type="text/javascript">
+      <script>
           var DOCUMENTATION_OPTIONS = {
               URL_ROOT:'{{ url_root }}',
               VERSION:'{{ release|e }}',
@@ -74,10 +74,10 @@
           };
       </script>
       {%- for scriptfile in script_files %}
-        <script type="text/javascript" src="{{ pathto(scriptfile, 1) }}"></script>
+        <script src="{{ pathto(scriptfile, 1) }}"></script>
       {%- endfor %}
     {%- endif %}
-    <script type="text/javascript" src="{{ pathto('_static/js/theme.js', 1) }}"></script>
+    <script src="{{ pathto('_static/js/theme.js', 1) }}"></script>
 
     {#- OPENSEARCH #}
     {%- if use_opensearch %}
@@ -209,7 +209,7 @@
   </div>
   {% include "versions.html" -%}
 
-  <script type="text/javascript">
+  <script>
       jQuery(function () {
           SphinxRtdTheme.Navigation.enable({{ 'true' if theme_sticky_navigation|tobool else 'false' }});
       });

--- a/sphinx_rtd_theme/search.html
+++ b/sphinx_rtd_theme/search.html
@@ -12,16 +12,16 @@
 {% set display_vcs_links = False %}
 {%- block scripts %}
     {{ super() }}
-    <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
-    <script type="text/javascript" src="{{ pathto('_static/language_data.js', 1) }}"></script>
+    <script src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block footer %}
-  <script type="text/javascript">
+  <script>
     jQuery(function() { Search.loadIndex("{{ pathto('searchindex.js', 1) }}"); });
   </script>
   {# this is used when loading the search index using $.ajax fails,
      such as on Chrome for documents on localhost #}
-  <script type="text/javascript" id="searchindexloader"></script>
+  <script id="searchindexloader"></script>
   {{ super() }}
 {% endblock %}
 {% block body %}


### PR DESCRIPTION
`type="text/javascript"` is unnecessary and even discouraged by the [specification](https://html.spec.whatwg.org/multipage/scripting.html#attr-script-type): “Authors should omit the type attribute instead of redundantly setting it.”

It causes the validator to raise [warnings](https://validator.w3.org/nu/?doc=data%3Atext%2Fhtml%2C%3C!DOCTYPE+html%3E%3Chtml+lang%3Den%3E%3Cmeta+charset%3DUTF-8%3E%3Ctitle%3ETest%3C%2Ftitle%3E%3Cscript+type%3D%22text%2Fjavascript%22+src%3D%22test.js%22%3E%3C%2Fscript%3E), too.