### PR TITLE
Maintain aria-expanded along with .current in menu

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -145,11 +145,19 @@ function ThemeNav () {
             // If we found a matching link then reset current and re-apply
             // otherwise retain the existing match
             if (link.length > 0) {
-                $('.wy-menu-vertical .current').removeClass('current');
-                link.addClass('current');
-                link.closest('li.toctree-l1').parent().addClass('current');
+                $('.wy-menu-vertical .current')
+                    .removeClass('current')
+                    .attr('aria-expanded','false');
+                link.addClass('current')
+                    .attr('aria-expanded','true');
+                link.closest('li.toctree-l1')
+                    .parent()
+                    .addClass('current')
+                    .attr('aria-expanded','true');
                 for (let i = 1; i <= 10; i++) {
-                    link.closest('li.toctree-l' + i).addClass('current');
+                    link.closest('li.toctree-l' + i)
+                        .addClass('current')
+                        .attr('aria-expanded','true');
                 }
                 link[0].scrollIntoView();
             }
@@ -188,13 +196,26 @@ function ThemeNav () {
 
     nav.toggleCurrent = function (elem) {
         var parent_li = elem.closest('li');
-        parent_li.siblings('li.current').removeClass('current');
-        parent_li.siblings().find('li.current').removeClass('current');
+        parent_li
+            .siblings('li.current')
+            .removeClass('current')
+            .attr('aria-expanded','false');
+        parent_li
+            .siblings()
+            .find('li.current')
+            .removeClass('current')
+            .attr('aria-expanded','false');
         var children = parent_li.find('> ul li');
         // Don't toggle terminal elements.
         if (children.length) {
-            children.removeClass('current');
-            parent_li.toggleClass('current');
+            children
+                .removeClass('current')
+                .attr('aria-expanded','false');
+            parent_li
+                .toggleClass('current')
+                .attr('aria-expanded', function(i, old) {
+                    return old == 'true' ? 'false' : 'true';
+                });
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/readthedocs/sphinx_rtd_theme/issues/955

It might be faster to chain the jQuery calls together to avoid running searches twice, or searching for `$('.current')` and applying the aria attribute. However just kicking off this PR with a basic fix.