### PR TITLE
Align prev/next without pseudo-element

### DIFF
--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -1,12 +1,16 @@
 <footer>
   {%- if (theme_prev_next_buttons_location == 'bottom' or theme_prev_next_buttons_location == 'both') and (next or prev) %}
     <div class="rst-footer-buttons" role="navigation" aria-label="{{ _('Footer') }}">
+	  <div class="column">
       {%- if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+        <a href="{{ prev.link|e }}" class="btn btn-neutral" title="{{ prev.title|striptags|e }}" accesskey="p" rel="prev"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
       {%- endif %}
+	  </div>
+	  <div class="column">
       {%- if next %}
         <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n" rel="next">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
       {%- endif %}
+	  </div>
     </div>
   {%- endif %}
 

--- a/src/sass/_theme_layout.sass
+++ b/src/sass/_theme_layout.sass
@@ -351,9 +351,11 @@ footer
     color: $footer-color
 
 .rst-footer-buttons
-  &:before, &:after
-    width: 100%
-  +clearfix
+  display: flex
+  flex-direction: row
+
+  .column
+    width: 50%
 
 .rst-breadcrumbs-buttons
   margin-top: 12px


### PR DESCRIPTION
Fixes https://github.com/readthedocs/sphinx_rtd_theme/issues/951

Slightly uglier HTML, and an asymmetry in the float attribute between buttons, but should remove an extra stop in a screenreader.