### PR TITLE
Add whitespace after elements with property class

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -447,6 +447,8 @@
     .property
       display: inline-block
       padding-right: 8px
+      &:after
+        content: " "
   // Doc links to sourcecode
   .viewcode-link, .viewcode-back
     display: inline-block


### PR DESCRIPTION
This fixes double-clicking to select a single word since there is no whitespace between it and the next element.

Fixes: #1154