### PR TITLE
Show keyboard focus on buttons

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -209,6 +209,10 @@
     &:hover .headerlink:after
       visibility: visible
 
+  // override the Wyrm accessibility anti-pattern of hiding button focus
+  .btn:focus
+    outline: 2px solid
+
   table > caption .headerlink:after
     font-size: 12px
 


### PR DESCRIPTION
The Wyrm SASS theme uses an accessibility anti-pattern of hiding keyboard focus events on buttons. I modified our theme to override that.

Later on it might also be good to contribute a fix upstream, but I'm under a deadline and don't want to involve more moving parts.
https://github.com/snide/wyrm/blob/fd41b56978f009e8c33cb26f384dd0dfaf430a7d/sass/wyrm_core/_button.sass#L79-L81

Fixes https://github.com/readthedocs/sphinx_rtd_theme/issues/958