### PR TITLE
Allow keyboard to activate permalink

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -56,6 +56,9 @@ def setup(app):
         app.connect('config-inited', config_initiated)
 
     # sphinx emits the permalink icon for headers, so choose one more in keeping with our theme
-    app.config.html_permalinks_icon = "🔗"
+    if sphinx_version >= (3, 5, 0):
+        app.config.html_permalinks_icon = "🔗"
+    else:
+        app.config.html_add_permalinks = "🔗"
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -55,4 +55,7 @@ def setup(app):
         app.add_message_catalog('sphinx', rtd_locale_path)
         app.connect('config-inited', config_initiated)
 
+    # sphinx emits the permalink icon for headers, so choose one more in keeping with our theme
+    app.config.html_permalinks_icon = "🔗"
+
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -57,8 +57,8 @@ def setup(app):
 
     # sphinx emits the permalink icon for headers, so choose one more in keeping with our theme
     if sphinx_version >= (3, 5, 0):
-        app.config.html_permalinks_icon = "🔗"
+        app.config.html_permalinks_icon = "\uf0c1"
     else:
-        app.config.html_add_permalinks = "🔗"
+        app.config.html_add_permalinks = "\uf0c1"
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -200,14 +200,14 @@
   // This is the #href that shows up on hover. Sphinx's is terrible so I hack it away.
   h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
     .headerlink
-      visibility: hidden
-      font-size: 14px
+      opacity: 0
+      font-size: 18px
+      margin-left: 0.5em
       @extend .fa
-      &:after
-        content: "\f0c1"
-        font-family: FontAwesome
-    &:hover .headerlink:after
-      visibility: visible
+      &:focus
+        opacity: 1
+    &:hover .headerlink
+      opacity: 1
 
   // override the Wyrm accessibility anti-pattern of hiding button focus
   .btn:focus

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -201,7 +201,7 @@
   h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
     .headerlink
       opacity: 0
-      font-size: 18px
+      font-size: 20px
       margin-left: 0.5em
       @extend .fa
       &:focus

--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -201,7 +201,8 @@
   h1, h2, h3, h4, h5, h6, dl dt, p.caption, table > caption, .code-block-caption
     .headerlink
       opacity: 0
-      font-size: 20px
+      font-size: 14px
+      font-family: FontAwesome
       margin-left: 0.5em
       @extend .fa
       &:focus


### PR DESCRIPTION
Fixes https://github.com/readthedocs/sphinx_rtd_theme/issues/956

In the new behavior, permalinks are hidden but are present for keyboard focus. When you tab into them they appear. They also appear when you mouse over the headers, as before.

The only downside is that we're falling back to using sphinx's ¶ symbol, which doesn't look as nice as fontawesome's chain link icon. However I think that's a price we have to pay for accessibility.