### PR TITLE
fix tests with Sphinx 4.1.0

### DIFF
--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -3,7 +3,11 @@ import os
 import pytest
 import sphinx
 from sphinx import addnodes
-from sphinx.builders.html import SingleFileHTMLBuilder, DirectoryHTMLBuilder
+try:
+    from sphinx.builders.html import SingleFileHTMLBuilder, DirectoryHTMLBuilder
+except ImportError:
+    from sphinx.builders.singlehtml import SingleFileHTMLBuilder
+    from sphinx.builders.dirhtml import DirectoryHTMLBuilder
 
 from .util import build_all
 


### PR DESCRIPTION
Sphinx 4.1.0 dropped their deprecated aliases (https://github.com/sphinx-doc/sphinx/commit/b84357be49819e3a08d7ca16a96031afb27418be). This patch fixes the test build with new Sphinx.