### PR TITLE
Added missing space char in footer

### DIFF
--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -51,9 +51,9 @@
     {#- Translators: the variable "sphinx_web" is a link to the Sphinx project documentation with the text "Sphinx" #}
     {%- trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %}
     {#- Translators: "theme" refers to a theme for Sphinx, which alters the appearance of the generated documenation #}
-    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %} </a>
+    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a>
     {#- Translators: this is always used as "provided by Read the Docs", and should not imply Read the Docs is an author of the generated documentation. #}
-    {%- trans %}provided by {{ readthedocs_web }}{% endtrans %}.
+    {% trans %}provided by {{ readthedocs_web }}{% endtrans %}.
   {% endif %}
 
   {%- block extrafooter %} {% endblock %}

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -51,7 +51,7 @@
     {#- Translators: the variable "sphinx_web" is a link to the Sphinx project documentation with the text "Sphinx" #}
     {%- trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %}
     {#- Translators: "theme" refers to a theme for Sphinx, which alters the appearance of the generated documenation #}
-    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a>
+    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %} </a>
     {#- Translators: this is always used as "provided by Read the Docs", and should not imply Read the Docs is an author of the generated documentation. #}
     {%- trans %}provided by {{ readthedocs_web }}{% endtrans %}.
   {% endif %}


### PR DESCRIPTION
Added back a missing space character to the footer that was probably lost among the translation lines.