### PR TITLE
Drop sphinx config from bump2version config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,5 +52,3 @@ replace = "version": "{new_version}",
 [bumpversion:file:package-lock.json]
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
-
-[bumpversion:file:docs/conf.py]


### PR DESCRIPTION
There is no hardcoded version in the docs now