### PR TITLE
Bump to 1.0alpha1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,11 +2,10 @@
 Changelog
 *********
 
-master
-======
+Development version (|development_version|)
+===========================================
 
-v1.0.0
-======
+.. |development_version| replace:: 1.0.0alpha1
 
 Incompatible Changes
 --------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -197,4 +197,8 @@ To release a new version of the theme, core team will take the following steps:
       $ python setup.py sdist bdist_wheel
       $ twine upload --sign --identity security@readthedocs.org dist/*
 
+#. Finally, open a new pull request updating the development release version to
+   the next patch by running ``bump2version patch``. Open a pull request with
+   this change.
+
 .. _PEP440: https://www.python.org/dev/peps/pep-0440/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx_rtd_theme",
-  "version": "0.5.2",
+  "version": "1.0.0alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2809,7 +2809,7 @@
       }
     },
     "fresh": {
-      "version": "0.5.2",
+      "version": "1.0.0alpha1",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
       "dev": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphinx_rtd_theme",
   "main": "js/theme.js",
-  "version": "0.5.2",
+  "version": "1.0.0alpha1",
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,3 +52,7 @@ replace = "version": "{new_version}",
 [bumpversion:file:package-lock.json]
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
+
+[bumpversion:file:docs/changelog.rst]
+search = .. |development_version| replace:: {current_version}
+replace = .. |development_version| replace:: {new_version}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.5.2
+current_version = 1.0.0alpha1
 commit = false
 tag = false
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<dev>\d+))?

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,5 +52,3 @@ replace = "version": "{new_version}",
 [bumpversion:file:package-lock.json]
 search = "version": "{current_version}",
 replace = "version": "{new_version}",
-
-[bumpversion:file:docs/conf.py]

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ class TransifexCommand(distutils.cmd.Command):
 
 setup(
     name='sphinx_rtd_theme',
-    version='0.5.2',
+    version='1.0.0alpha1',
     url='https://github.com/readthedocs/sphinx_rtd_theme',
     license='MIT',
     author='Dave Snider, Read the Docs, Inc. & contributors',

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -12,7 +12,7 @@ from sphinx.locale import _
 from sphinx.util.logging import getLogger
 
 
-__version__ = '0.5.2'
+__version__ = '1.0.0alpha1'
 __version_full__ = __version__
 
 logger = getLogger(__name__)


### PR DESCRIPTION
I think we talked about this and never followed through on the next few 
release, not sure though. After we release a new version, I think we should
be updating the repository version to something other than the most current
release.

The effect would be that the version in the repository would be an 
alpha/dev release, and so would be possible to differentiate easily between
0.5.2 release on PyPI and 0.5.3alpha1 development release from Git. Right
now, we don't follow up with incrementing this version, and so it's harder
to tell the difference. This is mostly for our use in development.

It adds a small bit of overhead, but is nice and explicit.

This PR updates the version in the repository to 1.0.0alpha1. If we had 
adopted this workflow, the progression would have been:

* Release 0.5.2, open PR bumping to 0.5.2 (run `bump2version release` and open PR)
* Follow up 0.5.2 release by bumping to `0.5.3alpha1` (run `bump2version patch` and open PR)
* We add a new feature, bump to `0.6.0alpha1` (run `bump2version minor` and open PR)
* Oops, backwards incompatible change. We bump to `1.0.0alpha1` (run `bump2version major` and open PR)
* We're ready for an rc, bump to `1.0.0rc1` (run `bump2version release` and open PR)
* Maybe we cut another rc after some fixes
* We're ready for final release, bump to `1.0.0` (run `bump2version release` and open PR)
* Follow up the release PR by bumping to the next version (run `bump2version patch` and open PR)