### PR TITLE
Make section labels verbose to avoid numeric labels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -59,7 +59,7 @@ Other Changes
 * Use regular toctree instead of toc for singlehtml builder (#507)
 * Cleanup whitespace in templates (#1060)
 
-.. _0.5.2:
+.. _release-0.5.2:
 
 0.5.2
 =====
@@ -71,7 +71,7 @@ Other Changes
 
 * Depend on docutils < 0.17 (#1113)
 
-.. _0.5.1:
+.. _release-0.5.1:
 
 0.5.1
 =====
@@ -103,7 +103,7 @@ Other Changes
 * Make Copyright template match sphinx's basic (#933)
 * Packaging: include ``bin/preinstall.js`` (#1005)
 
-.. _0.5.0:
+.. _release-0.5.0:
 
 0.5.0
 =====
@@ -114,6 +114,8 @@ Fixes
 -----
 
 * Fix bullet list spacing to respect simple/complex list styles
+
+.. _release-0.5.0rc2:
 
 0.5.0rc2
 ========
@@ -127,6 +129,8 @@ Fixes
 * Change FOUT back to FOIT
 * Fix several margin issues with lists, nested lists, and nested content
 * Add colon back to field lists
+
+.. _release-0.5.0rc1:
 
 0.5.0rc1
 ========
@@ -147,7 +151,7 @@ Other Changes
 * Moved build system from Grunt and friends to Webpack
 * Remove Modernizr, but keep html5shiv (#724, #525)
 
-.. _0.4.3:
+.. _release-0.4.3:
 
 0.4.3
 =====
@@ -169,7 +173,7 @@ Fixes
 Other Changes
 --------------
 
-.. _0.4.2:
+.. _release-0.4.2:
 
 0.4.2
 =====

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -94,7 +94,7 @@ version:
 
 .. _semantic versioning: http://semver.org/
 
-.. _1.0.0:
+.. _release-1.0.0:
 
 1.0.0
 ~~~~~
@@ -126,7 +126,7 @@ HTML4 support is deprecated
     Support for the Sphinx HTML4 writer will be removed in the :ref:`2.0.0`
     release.
 
-.. _1.1.0:
+.. _release-1.1.0:
 
 1.1.0
 ~~~~~
@@ -138,7 +138,7 @@ the 1.x release series. The 1.1 release will not be adding any major features
 and will instead mark the last release targeting projects with old dependencies
 like Sphinx 1.8, HTML4, or required support for IE11.
 
-.. _2.0.0:
+.. _release-2.0.0:
 
 2.0.0
 ~~~~~
@@ -166,7 +166,7 @@ HTML4 support will be removed
     support and should no longer be required to use a modern combination of this
     theme and Sphinx.
 
-.. _3.0.0:
+.. _release-3.0.0:
 
 3.0.0
 ~~~~~


### PR DESCRIPTION
Perhaps this is a feature of Sphinx I'm not aware of, but using a
version number as the section label resulted in ``#id1`` instead.

I tried autosectionlabel, but as expected there were a lot of errors and
I don't feel it's worthwhile to spend time fixing them right now.