### PR TITLE
Use consistent indentation in src/sass/_theme_rst.sass

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -106,11 +106,11 @@
       pointer-events: none
 
     span.linenos
-     display: inline-block
-     padding-left: 0px
-     padding-right: ($base-line-height / 2)
-     margin-right: ($base-line-height / 2)
-     border-right: 1px solid lighten($table-border-color, 2%)
+      display: inline-block
+      padding-left: 0px
+      padding-right: ($base-line-height / 2)
+      margin-right: ($base-line-height / 2)
+      border-right: 1px solid lighten($table-border-color, 2%)
 
   .code-block-caption
     font-style: italic


### PR DESCRIPTION
Without this, I get this error when building the theme in Debian:

```
Error: Inconsistent indentation: 5 spaces were used for indentation, but the rest of the document was indented using 2 spaces.
        on line 109 of src/sass/_theme_rst.sass
        from line 47 of src/sass/theme.sass
```