### PR TITLE
Show version for Sphinx and this template in footer.

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -31,6 +31,9 @@ def config_initiated(app, config):
             _('The canonical_url option is deprecated, use the html_baseurl option from Sphinx instead.')
         )
 
+def update_context(app, pagename, templatename, context, doctree):
+    context["rtd_theme_version"] = __version_full__
+
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
     if python_version[0] < 3:
@@ -60,4 +63,5 @@ def setup(app):
     else:
         app.config.html_add_permalinks = "\uf0c1"
 
+    app.connect("html-page-context", update_context)
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_rtd_theme/footer.html
+++ b/sphinx_rtd_theme/footer.html
@@ -47,12 +47,12 @@
   </div>
 
   {% if show_sphinx %}
-    {%- set sphinx_web = '<a href="https://www.sphinx-doc.org/">Sphinx</a>' %}
+    {%- set sphinx_web = ('<a href="https://www.sphinx-doc.org/">Sphinx ' + sphinx_version + '</a>') %}
     {%- set readthedocs_web = '<a href="https://readthedocs.org">Read the Docs</a>'  %}
     {#- Translators: the variable "sphinx_web" is a link to the Sphinx project documentation with the text "Sphinx" #}
     {%- trans sphinx_web=sphinx_web, readthedocs_web=readthedocs_web %}Built with {{ sphinx_web }} using a{% endtrans %}
     {#- Translators: "theme" refers to a theme for Sphinx, which alters the appearance of the generated documenation #}
-    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %}</a>
+    <a href="https://github.com/readthedocs/sphinx_rtd_theme">{% trans %}theme{% endtrans %} {{ rtd_theme_version }}</a>
     {#- Translators: this is always used as "provided by Read the Docs", and should not imply Read the Docs is an author of the generated documentation. #}
     {% trans %}provided by {{ readthedocs_web }}{% endtrans %}.
   {% endif %}


### PR DESCRIPTION
Emits now:

![Screenshot from 2021-12-28 15-08-29](https://user-images.githubusercontent.com/2658545/147574595-e9af9a9f-e259-4229-8acf-fdcbcd4692a1.png)
