### PR TITLE
fixed the issue of Unequal number of <div> and </div> in sphinx_rtd_theme/layout.html 

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -223,6 +223,7 @@
         </div>
       {%- endblock %}
       </div>
+     </div>
     </section>
   </div>
   {% include "versions.html" -%}


### PR DESCRIPTION
I have fixed the issue of Unequal number of <div> and </div> in sphinx_rtd_theme/layout.html. Now its both equal.

Please review and merge my PR.
Thanks!