### PR TITLE
Fix failing CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ jobs:
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
           echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
           echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
+          nvm install v15.14.0
       - run-build: {}
   py27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,13 @@ commands:
     description: "Ensure built assets are up to date"
     steps:
       - checkout
+      - run:
+          name: Install Node
+          command: |
+            curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+            echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
+            echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
+            nvm install v15.14.0
       - run: npm ci
       - run: npm run build
       - run:
@@ -34,11 +41,6 @@ jobs:
     docker:
       - image: 'cimg/python:3.9-node'
     steps:
-      - run: |
-          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-          echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
-          echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
-          nvm install v15.14.0
       - run-build: {}
   py27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,8 @@ commands:
 jobs:
   build:
     docker:
-      - image: 'cimg/python:3.9-node'
+      - image: 'cimg/python:3.9'
+      - image: 'cimg/node:15.14.0'
     steps:
       - run-build: {}
   py27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs:
     docker:
       - image: 'cimg/python:3.9'
     steps:
-      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-      - nvm install v15.14.0
+      - run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+      - run: nvm install v15.14.0
       - run-build: {}
   py27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     docker:
       - image: 'cimg/python:3.9-node'
     steps:
-      - command: |
+      - run: |
           curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
           echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
           echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: 'cimg/python:3.9'
+      - image: 'cimg/python:3.9-node'
     steps:
       - run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
       - run: source ~/.bashrc

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,8 +33,9 @@ jobs:
   build:
     docker:
       - image: 'cimg/python:3.9'
-      - image: 'cimg/node:15.14.0'
     steps:
+      - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+      - nvm install v15.14.0
       - run-build: {}
   py27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,10 @@ jobs:
     docker:
       - image: 'cimg/python:3.9-node'
     steps:
-      - run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-      - run: source ~/.bashrc
-      - run: nvm install v15.14.0
+      - command: |
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+          echo 'export NVM_DIR=$HOME/.nvm' >> $BASH_ENV
+          echo 'source $NVM_DIR/nvm.sh' >> $BASH_ENV
       - run-build: {}
   py27:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,7 @@ jobs:
       - image: 'cimg/python:3.9'
     steps:
       - run: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
+      - run: source ~/.bashrc
       - run: nvm install v15.14.0
       - run-build: {}
   py27:


### PR DESCRIPTION
Issue was newer node versions are not compatible with our dev envorment.
This failed because the `cimg/python:3.9-node` defaulted to a newer version of node.
To fix this we can use multiple images to specify a specific node version.

I settled on `node:15.14.0` as it is the last working version.

After we get tests passing we can work on supporting newer node versions.