### PR TITLE
Revert change to JS package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sphinx_rtd_theme",
-  "version": "1.1.0-alpha.0",
+  "version": "1.0.1alpha1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphinx_rtd_theme",
   "main": "js/theme.js",
-  "version": "1.1.0-alpha.0",
+  "version": "1.0.1alpha1",
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",


### PR DESCRIPTION
This matches the version number in the Python package, and allows
bumpversion to continue working. We can revisit changing this version
later, but currently this version will never be updated again, as
bumpversion will not match this string anymore.

Fixes #1326