### PR TITLE
Add an upper bound for when Sphinx 6 is released

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ include_package_data = True
 zip_safe = False
 packages = sphinx_rtd_theme
 install_requires =
-  sphinx >=1.6
+  sphinx >=1.6,<6
   docutils <0.18
   Jinja2 <3.1
 tests_require =


### PR DESCRIPTION
Fixes #1282

This should ideally break the tox `*-sphinxlatest` build once Sphinx 6.x is released.