### PR TITLE
Support Sphinx post-releases

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -10,8 +10,8 @@
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
 {# Build sphinx_version_info tuple from sphinx_version string in pure Jinja #}
-{%- set (_ver_major, _ver_minor, _ver_bugfix) = sphinx_version.split('.') | map('int') -%}
-{%- set sphinx_version_info = (_ver_major, _ver_minor, _ver_bugfix) -%}
+{%- set (_ver_major, _ver_minor) = sphinx_version.split('.')[:2] | map('int') -%}
+{%- set sphinx_version_info = (_ver_major, _ver_minor) -%}
 
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >


### PR DESCRIPTION
Fixes #1343, the way this string is being separated was not safe for Sphinx's pypi pre-release/post-release versions.

This includes current release `5.2.0.post0`, but also applies to previous pypi beta releases such as `5.0.0b1`

As the `_ver_bugfix` is not being used within templates, we can slice to only include `major` and `minor` components. 
This avoids issues from the `patch` component being non-integer as well the `len(sphinx_version.split('.'))` being > 3.