### PR TITLE
Update layout.html to support a sphinx version that is not three-integers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,9 @@ install_requires =
   sphinx >=1.6,<6
   docutils <0.18
   Jinja2 <3.1
+  packaging
 tests_require =
+  readthedocs-sphinx-ext
   pytest
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,9 +37,7 @@ install_requires =
   sphinx >=1.6,<6
   docutils <0.18
   Jinja2 <3.1
-  packaging
 tests_require =
-  readthedocs-sphinx-ext
   pytest
 
 [options.extras_require]

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -7,6 +7,7 @@ From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 from os import path
 from sys import version_info as python_version
 
+import packaging.version
 from sphinx import version_info as sphinx_version
 from sphinx.locale import _
 from sphinx.util.logging import getLogger
@@ -30,6 +31,12 @@ def config_initiated(app, config):
         logger.warning(
             _('The canonical_url option is deprecated, use the html_baseurl option from Sphinx instead.')
         )
+
+
+def extend_html_context(app, pagename, templatename, context, doctree):
+     # Extend the page context to be albe to parse versions correctly.
+     context['parse_version'] = packaging.version.parse
+
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
@@ -59,5 +66,8 @@ def setup(app):
         app.config.html_permalinks_icon = "\uf0c1"
     else:
         app.config.html_add_permalinks = "\uf0c1"
+
+    # Extend the default context when rendering the templates.
+    app.connect("html-page-context", extend_html_context)
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -7,7 +7,6 @@ From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 from os import path
 from sys import version_info as python_version
 
-import packaging.version
 from sphinx import version_info as sphinx_version
 from sphinx.locale import _
 from sphinx.util.logging import getLogger
@@ -34,8 +33,8 @@ def config_initiated(app, config):
 
 
 def extend_html_context(app, pagename, templatename, context, doctree):
-     # Extend the page context to be albe to parse versions correctly.
-     context['parse_version'] = packaging.version.parse
+     # Add ``sphinx_version_info`` tuple for use in Jinja templates
+     context['sphinx_version_info'] = sphinx_version[:3]
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -34,7 +34,7 @@ def config_initiated(app, config):
 
 def extend_html_context(app, pagename, templatename, context, doctree):
      # Add ``sphinx_version_info`` tuple for use in Jinja templates
-     context['sphinx_version_info'] = sphinx_version[:3]
+     context['sphinx_version_info'] = sphinx_version
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -9,9 +9,7 @@
 {%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
-{# Build sphinx_version_info tuple from sphinx_version string in pure Jinja #}
-{%- set (_ver_major, _ver_minor, _ver_bugfix) = sphinx_version.split('.') | map('int') -%}
-{%- set sphinx_version_info = (_ver_major, _ver_minor, _ver_bugfix) -%}
+{%- set sphinx_vn = parse_version(sphinx_version) -%}
 
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >
@@ -24,7 +22,7 @@
   {%- endblock -%}
 
   {#- CSS #}
-  {%- if sphinx_version_info < (4, 0) -%}
+  {%- if sphinx_vn < parse_version("4.0") -%}
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- endif %}
@@ -42,7 +40,7 @@
 
   {#- FAVICON #}
   {%- if favicon %}
-    {%- if sphinx_version_info < (4, 0) -%}
+    {%- if sphinx_vn < parse_version("4.0") -%}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- else %}
     <link rel="shortcut icon" href="{{ favicon_url }}"/>
@@ -66,8 +64,8 @@
   <![endif]-->
   {%- if not embedded %}
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
-    {%- if sphinx_version_info >= (1, 8) -%}
-      {%- if sphinx_version_info < (4, 0) -%}
+    {%- if sphinx_vn >= parse_version("1.8") -%}
+      {%- if sphinx_vn < parse_version("4.0") -%}
       <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
       {%- endif -%}
       {%- for scriptfile in script_files %}
@@ -143,7 +141,7 @@
             {#- Not strictly valid HTML, but it's the only way to display/scale
                 it properly, without weird scripting or heaps of work
             #}
-            {%- if sphinx_version_info < (4, 0) -%}
+            {%- if sphinx_vn < parse_version("4.0") -%}
             <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
             {%- else %}
             <img src="{{ logo_url }}" class="logo" alt="{{ _('Logo') }}"/>

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -9,8 +9,6 @@
 {%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
-{%- set sphinx_vn = parse_version(sphinx_version) -%}
-
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >
 <head>
@@ -22,7 +20,7 @@
   {%- endblock -%}
 
   {#- CSS #}
-  {%- if sphinx_vn < parse_version("4.0") -%}
+  {%- if sphinx_version_info < (4, 0) -%}
     <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- endif %}
@@ -40,7 +38,7 @@
 
   {#- FAVICON #}
   {%- if favicon %}
-    {%- if sphinx_vn < parse_version("4.0") -%}
+    {%- if sphinx_version_info < (4, 0) -%}
     <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}"/>
     {%- else %}
     <link rel="shortcut icon" href="{{ favicon_url }}"/>
@@ -64,8 +62,8 @@
   <![endif]-->
   {%- if not embedded %}
   {# XXX Sphinx 1.8.0 made this an external js-file, quick fix until we refactor the template to inherert more blocks directly from sphinx #}
-    {%- if sphinx_vn >= parse_version("1.8") -%}
-      {%- if sphinx_vn < parse_version("4.0") -%}
+    {%- if sphinx_version_info >= (1, 8) -%}
+      {%- if sphinx_version_info < (4, 0) -%}
       <script id="documentation_options" data-url_root="{{ url_root }}" src="{{ pathto('_static/documentation_options.js', 1) }}"></script>
       {%- endif -%}
       {%- for scriptfile in script_files %}
@@ -141,7 +139,7 @@
             {#- Not strictly valid HTML, but it's the only way to display/scale
                 it properly, without weird scripting or heaps of work
             #}
-            {%- if sphinx_vn < parse_version("4.0") -%}
+            {%- if sphinx_version_info < (4, 0) -%}
             <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
             {%- else %}
             <img src="{{ logo_url }}" class="logo" alt="{{ _('Logo') }}"/>


### PR DESCRIPTION
Update layout.html to support a sphinx version that is not three-integers.
Useful for ``sphinx==5.2.0.post0``, which would cause the theme to fail otherwise. Closes #1343.

Note that ``packaging`` is already a dependency transitively - but it is now an explicit dependency.

I added ``readthedocs-sphinx-ext`` as a test dependency, as I believe it is (and I couldn't get the tests passing locally without it).