### PR TITLE
Use the dependencies declaration to specify test dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,7 @@ install_requires =
   Jinja2 <3.1
 tests_require =
   pytest
+  readthedocs-sphinx-ext
 
 [options.extras_require]
 dev =

--- a/tox.ini
+++ b/tox.ini
@@ -8,10 +8,7 @@ envlist =
 setev =
     LANG=C
 deps =
-    .
-    readthedocs-sphinx-ext
-    pytest
-    sphinxcontrib-httpdomain
+    .[test,dev]
     sphinx16: Sphinx>=1.6,<1.7
     sphinx17: Sphinx>=1.7,<1.8
     sphinx18: Sphinx>=1.8,<1.9


### PR DESCRIPTION
Use the dependencies declaration to specify test dependencies, rather than embedding them in the tox.ini

cc @agjohnson following on from https://github.com/readthedocs/sphinx_rtd_theme/pull/1345#discussion_r981610393 (which I reverted in that PR)