### PR TITLE
Eager upgrade of all dependencies in docker development environment

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,7 +2,7 @@
 
 # Update latest Python dependencies in case they have changed
 cd /project-readonly
-pip install --upgrade -e ".[dev]"
+pip install --upgrade --upgrade-strategy eager -e ".[dev]"
 
 # This helps a potential permission issue, but might be removed
 # pending some more investigation of docker host file system


### PR DESCRIPTION
This helped me understand issues caused by jumping between old branches. The eager upgrade is over in a matter of ~6 second in my end, so I think it's worth it. Because of the ability to run the NPM development server, it's possible to skip this if working on SASS or docs/.