### PR TITLE
Move context logic for layout.html to jinja

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -45,6 +45,7 @@ Minor changes
 * Python 3.10 added to test matrix (#1334)
 * Supplemental Docker setup for development (#1319)
 * Most of setup.py migrated to setup.cfg (#1116)
+* Jinja2 context variable ``sphinx_version_info`` is now ``(major, minor, -1)``, the patch component is always ``-1``. Reason: It's complicated. (#1345)
 
 
 Incompatible Changes

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -31,12 +31,6 @@ def config_initiated(app, config):
             _('The canonical_url option is deprecated, use the html_baseurl option from Sphinx instead.')
         )
 
-
-def extend_html_context(app, pagename, templatename, context, doctree):
-     # Add ``sphinx_version_info`` tuple for use in Jinja templates
-     context['sphinx_version_info'] = sphinx_version
-
-
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
     if python_version[0] < 3:
@@ -65,8 +59,5 @@ def setup(app):
         app.config.html_permalinks_icon = "\uf0c1"
     else:
         app.config.html_add_permalinks = "\uf0c1"
-
-    # Extend the default context when rendering the templates.
-    app.connect("html-page-context", extend_html_context)
 
     return {'parallel_read_safe': True, 'parallel_write_safe': True}

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -10,8 +10,8 @@
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
 {# Build sphinx_version_info tuple from sphinx_version string in pure Jinja #}
-{%- set (_ver_major, _ver_minor, _ver_bugfix) = (sphinx_version.split('.') | map('int') | list)[:3] -%}
-{%- set sphinx_version_info = (_ver_major, _ver_minor, _ver_bugfix) -%}
+{%- set (_ver_major, _ver_minor) = (sphinx_version.split('.') | list)[:2] | map('int') -%}
+{%- set sphinx_version_info = (_ver_major, _ver_minor, -1) -%}
 
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -9,6 +9,10 @@
 {%- set lang_attr = 'en' if language == None else (language | replace('_', '-')) %}
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
+{# Build sphinx_version_info tuple from sphinx_version string in pure Jinja #}
+{%- set (_ver_major, _ver_minor, _ver_bugfix) = sphinx_version.split('.') | map('int') -%}
+{%- set sphinx_version_info = (_ver_major, _ver_minor, _ver_bugfix) -%}
+
 <!DOCTYPE html>
 <html class="{{ sphinx_writer }}" lang="{{ lang_attr }}" >
 <head>

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -10,7 +10,7 @@
 {%- set sphinx_writer = 'writer-html5' if html5_doctype else 'writer-html4' -%}
 
 {# Build sphinx_version_info tuple from sphinx_version string in pure Jinja #}
-{%- set (_ver_major, _ver_minor, _ver_bugfix) = sphinx_version.split('.') | map('int') -%}
+{%- set (_ver_major, _ver_minor, _ver_bugfix) = (sphinx_version.split('.') | map('int') | list)[:3] -%}
 {%- set sphinx_version_info = (_ver_major, _ver_minor, _ver_bugfix) -%}
 
 <!DOCTYPE html>


### PR DESCRIPTION
Reverts #1345 because we cannot rely on `setup(app)` for now
Fixes the symptom of #1355 