### PR TITLE
Replaces the Jinja2 dependecy with a meta package 🤯

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 install_requires = 
 	sphinx >=1.6,<6
 	docutils <0.18
-	Jinja2 <3.1
+	sphinx-rtd-theme-meta-jinja2-dependency
 tests_require = 
 	pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 install_requires = 
 	sphinx >=1.6,<6
 	docutils <0.18
-	sphinx-rtd-theme-meta-jinja2-dependency
+	sphinx-rtd-theme-meta-jinja2-dependency;python_version>='3'
 tests_require = 
 	pytest
 


### PR DESCRIPTION
This is a proposal for fixing #1358 

Notice that the sphinx-rtd-theme-meta-jinja2-dependency actually exists.

We only need this extra dependency for Python 3, since Jinja2 dropped Python 2.7 in version 3.0.0, so this will suffice as the upper bound for all Python 2 deployments.