### PR TITLE
Remove Jinja2 dependency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,11 +17,11 @@ Dependency Changes
 
 Many documentation projects depend on ``sphinx-rtd-theme`` without specifying a version of the theme (unpinned) while also depending on unpinned versions of Sphinx. The latest version of ``sphinx-rtd-theme`` ideally always supports the latest version of Sphinx, but this is now guaranteed.
 
-This release adds upper bounds to direct dependencies ``Sphinx``, ``docutils`` and ``Jinja2``, which will safeguard from mixing with possibly incompatible future versions of Sphinx & friends.
+This release adds upper bounds to direct dependencies ``Sphinx`` and ``docutils`` which will safeguard from mixing with possibly incompatible future versions of Sphinx & docutils.
 
 * Sphinx versions supported: 1.6 to 5.2.x
-* ``Jinja<3.1`` (#1316)
 * ``Sphinx<6`` (#1332)
+* ``docutils<0.18`` (unchanged, but will be bumped in an upcoming release)
 
 
 Features
@@ -38,7 +38,8 @@ Fixes
 * Definition lists rendered wrongly in api docs (#1052)
 * Citation not styled properly (#1078)
 
-Minor changes
+
+Minor Changes
 -------------
 
 * Sphinx 5.2 added to test matrix (#1348)

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,6 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
 install_requires = 
 	sphinx >=1.6,<6
 	docutils <0.18
-	Jinja2 <3.1
 tests_require = 
 	pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,10 @@ deps =
     # Projects using these Sphinx versions will have to do the same
     # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304
     sphinx{16,17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42}: docutils<0.18
+    # External environments are required to add this dependency for older versions of Sphinx
+    # because it didn't ship with this upper bound.
+    # See: https://github.com/sphinx-doc/sphinx/issues/10291
+    sphinx{16,17,18,20,21,22,23,24,30,31,32,33,34,35,40}: Jinja2<3.1
     sphinxlatest: Sphinx
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =


### PR DESCRIPTION
Adding this dependency would cause conflicts with existing projects.

The dependency is already injected for legacy projects hosted on Read the Docs. All other environments will have had to address the issue since it was addressed in https://github.com/sphinx-doc/sphinx/issues/10291.

Fixes #1358 