### PR TITLE
Added hidden text for home link in the breadcrumbs.

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -22,7 +22,7 @@
 <div role="navigation" aria-label="{{ _('Page navigation') }}">
   <ul class="wy-breadcrumbs">
     {%- block breadcrumbs %}
-      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home"><span class="visuallyhidden">Home</span></a></li>
+      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home" aria-label="{{ _('Home') }}"></a></li>
         {%- for doc in parents %}
           <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
         {%- endfor %}

--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -22,7 +22,7 @@
 <div role="navigation" aria-label="{{ _('Page navigation') }}">
   <ul class="wy-breadcrumbs">
     {%- block breadcrumbs %}
-      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home"></a></li>
+      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home"><span class="visuallyhidden">Home</span></a></li>
         {%- for doc in parents %}
           <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
         {%- endfor %}

--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -22,7 +22,7 @@
 <div role="navigation" aria-label="{{ _('Page navigation') }}">
   <ul class="wy-breadcrumbs">
     {%- block breadcrumbs %}
-      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home" aria-label="{{ _('Home') }}"></a></li>
+      <li><a href="{{ pathto(master_doc) }}" class="icon icon-home" aria-label="Home"></a></li>
         {%- for doc in parents %}
           <li class="breadcrumb-item"><a href="{{ doc.link|e }}">{{ doc.title }}</a></li>
         {%- endfor %}


### PR DESCRIPTION
Fixes another a11y issue where the home link in the breadcrumbs needs a text.

Wave report https://wave.webaim.org/report#/https://sphinx-rtd-theme.readthedocs.io/en/latest/contributing.html

![Wave report screenshot](https://user-images.githubusercontent.com/7096681/203170726-56f9cf9a-212f-4675-9fda-11c351afa24f.png)

Similar to #1379. Approach taken from https://fontawesome.com/v4/accessibility/. Let me know if I should also make an issue for this or if there is an existing issue.