### PR TITLE
support Python 3.11 with Sphinx 5.3+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,13 +77,23 @@ jobs:
     steps:
       - run-tox:
           version: py310
-          sphinx-version: "42,43,44,45,50,51,52,latest"
+          sphinx-version: "42,43,44,45,50,51,52,53,latest"
+  py311:
+    docker:
+      - image: 'cimg/python:3.11'
+    steps:
+      - run-tox:
+          version: py311
+          sphinx-version: "53,latest"
 
 workflows:
   version: 2
   tests:
     jobs:
       - build
+      - py311:
+          requires:
+            - build
       - py310:
           requires:
             - build

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,8 @@ Dependency Changes
 ------------------
 
 * docutils 0.18 is supported. (#1381)
+* Python 3.11 is officially supported and tested. (#1395)
+* Python 3.4 and 3.5 are officially not supported (#1395)
 
 Note for users of Sphinx<3
 --------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ classifiers =
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
+	Programming Language :: Python :: 3.11
 	Operating System :: OS Independent
 	Topic :: Documentation
 	Topic :: Software Development :: Documentation
@@ -42,7 +43,7 @@ classifiers =
 include_package_data = True
 zip_safe = False
 packages = sphinx_rtd_theme
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 install_requires = 
 	sphinx >=1.6,<6
 	docutils <0.19

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,9 @@ envlist =
     py{27}-sphinx{17,18}{-html4,-html5,}{-qa,}
     py{36,37,38,39}-sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52,latest}{-html4,-html5,}{-qa,}
     # Python 3.10 working from Sphinx 4.2 and up
-    py{310}-sphinx{42,43,44,45,50,51,52}{-html4,-html5,latest}{-qa,}
+    py{310}-sphinx{42,43,44,45,50,51,52,53,latest}{-html4,-html5}{-qa,}
+    # Python 3.11 working from Sphinx 5.3 and up
+    py{311}-sphinx{53,latest}{-html4,-html5}{-qa,}
 
 [testenv]
 setev =
@@ -35,6 +37,7 @@ deps =
     sphinx50: Sphinx>=5.0,<5.1
     sphinx51: Sphinx>=5.1,<5.2
     sphinx52: Sphinx>=5.2,<5.3
+    sphinx53: Sphinx>=5.3,<5.4
     # All these Sphinx versions actually break since docutils 0.18, so we need to add this upper bound
     # Projects using these Sphinx versions will have to do the same
     # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
     sphinx51: Sphinx>=5.1,<5.2
     sphinx52: Sphinx>=5.2,<5.3
     sphinx53: Sphinx>=5.3,<5.4
-    sphinx60: Sphinx==6.0.0
+    sphinx60: Sphinx>=6.0,<6.1
     # All these Sphinx versions actually break since docutils 0.18, so we need to add this upper bound
     # Projects using these Sphinx versions will have to do the same
     # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304


### PR DESCRIPTION
Local testing shows identical output using Sphinx 5.2 vs 5.3; and identical output using Sphinx 5.3 with Python 3.10 and Python 3.11

```
$ tox -e py310-sphinx53-html5 -e py310-sphinx52-html5 -e py311-sphinx53-html5
$ diff -r .tox/py310-sphinx53-html5/tmp/html/ .tox/py310-sphinx52-html5/tmp/html/
$ diff -r .tox/py310-sphinx53-html5/tmp/html/ .tox/py311-sphinx53-html5/tmp/html/
```
