### PR TITLE
Prevent permalink icon from wrapping alone

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -219,6 +219,7 @@
       font-size: 14px
       font-family: FontAwesome
       margin-left: 0.5em
+      display: inline
       @extend .fa
       &:focus
         opacity: 1


### PR DESCRIPTION
`.fa` styles sets `display` to `inline-block`. We force the `.headerlink` elements to stay `inline`, to make it wrap together with the previous word.

This should fix: #1412 
But I will wait @benjaoming to push the built assets to see the result.
