### PR TITLE
Do not use sphinxcontrib-jquery 3.0.0 but anticipate a fixed release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 install_requires = 
 	sphinx >=1.6,<7
 	docutils <0.19
-	sphinxcontrib-jquery >=2.0.0,!=3.0.0
+	sphinxcontrib-jquery >=2.0.0,!=3.0.0 ; python_version > '3'
 tests_require = 
 	pytest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 install_requires = 
 	sphinx >=1.6,<7
 	docutils <0.19
-	sphinxcontrib-jquery >=3.0.0
+	sphinxcontrib-jquery >=2.0.0,!=3.0.0
 tests_require = 
 	pytest
 


### PR DESCRIPTION
Fixes #1420 

I'll submit a fix for sphinxcontrib-jquery. Not sure what "next release" sphinxcontrib-jquery might choose, so I chose to not put an upper bound here (same reason that we didn't have one before, neither).

This also skips the dependency of sphinxcontrib-jquery on Python 2.7 systems.