### PR TITLE
Docs configuration: Remove from `sphinx-rtd-theme` from extensions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,6 @@ extensions = [
     'sphinx.ext.autosummary',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    'sphinx_rtd_theme',
 ]
 
 templates_path = ['_templates']


### PR DESCRIPTION
We should see a successful PR build with jQuery now that https://github.com/readthedocs/readthedocs.org/pull/9654 is merged and deployed.