### PR TITLE
Flyout: use the new integration point

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -4,6 +4,7 @@ Sphinx Read the Docs theme.
 From https://github.com/ryan-roemer/sphinx-bootstrap-theme.
 """
 
+import os
 from os import path
 from sys import version_info as python_version
 
@@ -35,6 +36,11 @@ def config_initiated(app, config):
 def extend_html_context(app, pagename, templatename, context, doctree):
      # Add ``sphinx_version_info`` tuple for use in Jinja templates
      context['sphinx_version_info'] = sphinx_version
+
+     # Populate the context with all the READTHEDOCS variables
+     for variable in os.environ:
+         if variable.startswith('READTHEDOCS'):
+             context[variable] = os.environ.get(variable)
 
 
 # See http://www.sphinx-doc.org/en/stable/theming.html#distribute-your-theme-as-a-python-package

--- a/sphinx_rtd_theme/versions.html
+++ b/sphinx_rtd_theme/versions.html
@@ -1,34 +1,3 @@
 {% if READTHEDOCS %}
-{# Add rst-badge after rst-versions for small badge style. #}
-  <div class="rst-versions" data-toggle="rst-versions" role="note" aria-label="{{ _('Versions') }}">
-    <span class="rst-current-version" data-toggle="rst-current-version">
-      <span class="fa fa-book"> Read the Docs</span>
-      v: {{ current_version }}
-      <span class="fa fa-caret-down"></span>
-    </span>
-    <div class="rst-other-versions">
-      <dl>
-        <dt>{{ _('Versions') }}</dt>
-        {% for slug, url in versions %}
-          <dd><a href="{{ url }}">{{ slug }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        <dt>{{ _('Downloads') }}</dt>
-        {% for type, url in downloads %}
-          <dd><a href="{{ url }}">{{ type }}</a></dd>
-        {% endfor %}
-      </dl>
-      <dl>
-        {# Translators: The phrase "Read the Docs" is not translated #}
-        <dt>{{ _('On Read the Docs') }}</dt>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/projects/{{ slug }}/?fromdocs={{ slug }}">{{ _('Project Home') }}</a>
-          </dd>
-          <dd>
-            <a href="//{{ PRODUCTION_DOMAIN }}/builds/{{ slug }}/?fromdocs={{ slug }}">{{ _('Builds') }}</a>
-          </dd>
-      </dl>
-    </div>
-  </div>
+<div id="readthedocs-embed-flyout"></div>
 {% endif %}


### PR DESCRIPTION
Use the documented integration point for our theme.
Read the official documentation at https://docs.readthedocs.io/en/stable/flyout-menu.html

I'm thinking about simplifying how all these integrations work and use only the ones that are documented. The idea is to inject the documented HTML tag that will be replaced by our integration at serve time.

Besides, I'm populating the template context with all the `READTHEDOCS` environment variables, so we can [stop passing them from the Read the Docs application at build time by injecting them into the `conf.py` file](https://github.com/readthedocs/readthedocs.org/blob/f83eee6964788a9a45cedf2ec48d211795a0362d/readthedocs/doc_builder/templates/doc_builder/conf.py.tmpl#L140).

Related: https://github.com/readthedocs/readthedocs.org/pull/10127