### PR TITLE
Add a call to add_js_files (sphinxcontrib.query)

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -10,6 +10,7 @@ from sys import version_info as python_version
 from sphinx import version_info as sphinx_version
 from sphinx.locale import _
 from sphinx.util.logging import getLogger
+from sphinxcontrib.jquery import add_js_files as jquery_add_js_files
 
 
 __version__ = '1.2.1alpha1'
@@ -58,6 +59,8 @@ def setup(app):
         # enabled at most once.
         # See: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.setup_extension
         app.setup_extension("sphinxcontrib.jquery")
+        # However, we need to call the extension's callback since setup_extension doesn't do it
+        jquery_add_js_files(app, app.config)
 
     # Register the theme that can be referenced without adding a theme path
     app.add_html_theme('sphinx_rtd_theme', path.abspath(path.dirname(__file__)))

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -10,7 +10,6 @@ from sys import version_info as python_version
 from sphinx import version_info as sphinx_version
 from sphinx.locale import _
 from sphinx.util.logging import getLogger
-from sphinxcontrib.jquery import add_js_files as jquery_add_js_files
 
 
 __version__ = '1.2.1alpha1'
@@ -60,6 +59,7 @@ def setup(app):
         # See: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.setup_extension
         app.setup_extension("sphinxcontrib.jquery")
         # However, we need to call the extension's callback since setup_extension doesn't do it
+        from sphinxcontrib.jquery import add_js_files as jquery_add_js_files
         jquery_add_js_files(app, app.config)
 
     # Register the theme that can be referenced without adding a theme path

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -59,6 +59,7 @@ def setup(app):
         # See: https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.setup_extension
         app.setup_extension("sphinxcontrib.jquery")
         # However, we need to call the extension's callback since setup_extension doesn't do it
+        # See: https://github.com/sphinx-contrib/jquery/issues/23
         from sphinxcontrib.jquery import add_js_files as jquery_add_js_files
         jquery_add_js_files(app, app.config)
 


### PR DESCRIPTION
The idea is that we need to force a call to `add_js_files` since it doesn't happen when loading extensions themes.

Presumably we can't do anything with `config-inited` in the theme, I can't see that the other signal is getting called - so for a bit of housekeeping, we should also delete this: https://github.com/readthedocs/sphinx_rtd_theme/blob/ee64d37ac95fcfe7a1e53d7ab72e09704606261e/sphinx_rtd_theme/__init__.py#L27-L32

See: https://github.com/sphinx-contrib/jquery/issues/23

Fixes #1452 