### PR TITLE
Bump to 1.3.0alpha1

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,7 +9,7 @@ Changelog
 |theme_version|
 ===============
 
-.. |theme_version| replace:: 1.2.1
+.. |theme_version| replace:: 1.3.0alpha1
 
 Fixes
 -----

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sphinx_rtd_theme",
   "main": "js/theme.js",
-  "version": "1.2.1",
+  "version": "1.3.0alpha1",
   "scripts": {
     "dev": "webpack-dev-server --open --config webpack.dev.js",
     "build": "webpack --config webpack.prod.js",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.1
+current_version = 1.3.0alpha1
 commit = false
 tag = false
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<dev>\d+))?

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ class TransifexCommand(distutils.cmd.Command):
 
 
 setup(
-    version='1.2.1',
+    version='1.3.0alpha1',
     cmdclass={
         'update_translations': UpdateTranslationsCommand,
         'transifex': TransifexCommand,

--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -12,7 +12,7 @@ from sphinx.locale import _
 from sphinx.util.logging import getLogger
 
 
-__version__ = '1.2.1'
+__version__ = '1.3.0alpha1'
 __version_full__ = __version__
 
 logger = getLogger(__name__)


### PR DESCRIPTION
1.2.1 is out now and seems to work well.

Let's decide to target 1.3.0 so we can get some highly-requested PRs merged and released? See: #1470 