### PR TITLE
require sphinxcontrib-jquery >=4.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
 install_requires = 
 	sphinx >=1.6,<7
 	docutils <0.19
-	sphinxcontrib-jquery >=2.0.0,!=3.0.0 ; python_version > '3'
+	sphinxcontrib-jquery >=4.0 ; python_version > '3'
 tests_require = 
 	pytest
 


### PR DESCRIPTION
https://github.com/readthedocs/sphinx_rtd_theme/commit/4d6de11137333ede9842d535aa08b753dcb7f1b0 adds an import to a function which only exists in `sphinxcontrib-jquery>=4.0`

Upgrading from `sphinx-rtd-theme==1.2.0` to `sphinx-rtd-theme==1.2.1` with `sphinxcontrib-jquery==2.0.0` already in your lockfile or virtualenv causes `ImportError: cannot import name 'add_js_files' from 'sphinxcontrib.jquery'` to be thrown.

This PR pins `sphinxcontrib-jquery` to a compatible range.