### PR TITLE
Set `display: block` on :py:`property`

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -546,7 +546,7 @@
       color: $black
       font-weight: bold
     .property
-      display: inline-block
+      display: block
       padding-right: 8px
       max-width: 100%
     // This is keywords such as "const"


### PR DESCRIPTION
:py:`property` blocks get rendered on a single line instead of separate lines Fixes #1301