### PR TITLE
Fix code-block linenumbers highlight on Safari

### DIFF
--- a/src/sass/_theme_rst.sass
+++ b/src/sass/_theme_rst.sass
@@ -103,6 +103,7 @@
   div.highlight
     span.linenos, .gp
       user-select: none
+      -webkit-user-select: none  // Safari fallback
       pointer-events: none
 
     span.linenos


### PR DESCRIPTION
## Issue
When using Safari and highlighting text in a code block with line numbers, the line numbers are also included. Line numbers are not included with eg. Firefox.

## How to reproduce
Open https://sphinx-rtd-theme.readthedocs.io/en/stable/demo/demo.html#emphasized-lines-with-line-numbers with Safari (I used v16.5.2) and highlight the code block. 
<img width="749" alt="image" src="https://github.com/readthedocs/sphinx_rtd_theme/assets/60272147/ab5e17e2-88a7-4f34-a45c-d466892a7e04">

## Expected behavior
Line numbers should not be included when highlighting.

# What is done
- Added the `-webkit-user-select: none` field. This is needed on Safari to disable highlighting. See https://developer.mozilla.org/en-US/docs/Web/CSS/user-select for details.
