### PR TITLE
2.0 milestone: drop supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,34 +40,48 @@ jobs:
       - image: 'cimg/python:3.9-node'
     steps:
       - run-build: {}
+  py36:
+    docker:
+      - image: 'cimg/python:3.6'
+    steps:
+      - run-tox:
+          version: py36
+          sphinx-version: "50,51,52,53"
+  py37:
+    docker:
+      - image: 'cimg/python:3.7'
+    steps:
+      - run-tox:
+          version: py37
+          sphinx-version: "50,51,52,53"
   py38:
     docker:
       - image: 'cimg/python:3.8'
     steps:
       - run-tox:
           version: py38
-          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,72,latest"
   py39:
     docker:
       - image: 'cimg/python:3.9'
     steps:
       - run-tox:
           version: py39
-          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,72,latest"
   py310:
     docker:
       - image: 'cimg/python:3.10'
     steps:
       - run-tox:
           version: py310
-          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,72,latest"
   py311:
     docker:
       - image: 'cimg/python:3.11'
     steps:
       - run-tox:
           version: py311
-          sphinx-version: "53,60,61,62,70,71,latest"
+          sphinx-version: "53,60,61,62,70,71,72,latest"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,13 +40,6 @@ jobs:
       - image: 'cimg/python:3.9-node'
     steps:
       - run-build: {}
-  py27:
-    docker:
-      - image: 'cimg/python:2.7'
-    steps:
-      - run-tox:
-          version: py27
-          sphinx-version: "17,18"
   py38:
     docker:
       - image: 'cimg/python:3.8'
@@ -91,8 +84,5 @@ workflows:
           requires:
             - build
       - py38:
-          requires:
-            - build
-      - py27:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - run-tox:
           version: py311
-          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
+          sphinx-version: "53,60,61,62,70,71,latest"
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,8 +14,12 @@ commands:
         default: "latest"
     steps:
       - checkout
-      - run: pip install --user tox
-      - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
+      # We cannot upgrade to Tox4 because running generative environments doesn't work.
+      # I guess it has changed its syntax or similar.
+      #   $ tox run -e "py310-sphinx{50,51}"
+      #   ROOT: HandledError| provided environments not found in configuration file: ['51}']
+      - run: pip install --user 'tox~=3.27'
+      - run: tox
   run-build:
     description: "Ensure built assets are up to date"
     steps:
@@ -98,5 +102,11 @@ workflows:
           requires:
             - build
       - py38:
+          requires:
+            - build
+      - py37:
+          requires:
+            - build
+      - py36:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,10 +11,10 @@ commands:
         type: string
       sphinx-version:
         type: string
-        default: "18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52,latest"
+        default: "latest"
     steps:
       - checkout
-      - run: pip install --user tox~=3.27
+      - run: pip install --user tox
       - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
   run-build:
     description: "Ensure built assets are up to date"
@@ -47,46 +47,34 @@ jobs:
       - run-tox:
           version: py27
           sphinx-version: "17,18"
-  py36:
-    docker:
-      - image: 'cimg/python:3.6'
-    steps:
-      - run-tox:
-          version: py36
-  py37:
-    docker:
-      - image: 'cimg/python:3.7'
-    steps:
-      - run-tox:
-          version: py37
   py38:
     docker:
       - image: 'cimg/python:3.8'
     steps:
       - run-tox:
           version: py38
-          sphinx-version: "18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52,60,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
   py39:
     docker:
       - image: 'cimg/python:3.9'
     steps:
       - run-tox:
           version: py39
-          sphinx-version: "18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52,60,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
   py310:
     docker:
       - image: 'cimg/python:3.10'
     steps:
       - run-tox:
           version: py310
-          sphinx-version: "42,43,44,45,50,51,52,53,60,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
   py311:
     docker:
       - image: 'cimg/python:3.11'
     steps:
       - run-tox:
           version: py311
-          sphinx-version: "53,60,latest"
+          sphinx-version: "50,51,52,53,60,61,62,70,71,latest"
 
 workflows:
   version: 2
@@ -103,12 +91,6 @@ workflows:
           requires:
             - build
       - py38:
-          requires:
-            - build
-      - py37:
-          requires:
-            - build
-      - py36:
           requires:
             - build
       - py27:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
       #   $ tox run -e "py310-sphinx{50,51}"
       #   ROOT: HandledError| provided environments not found in configuration file: ['51}']
       - run: pip install --user 'tox~=3.27'
-      - run: tox
+      - run: tox -e "<<parameters.version>>-sphinx{<<parameters.sphinx-version>>}"
   run-build:
     description: "Ensure built assets are up to date"
     steps:

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -143,36 +143,43 @@ like Sphinx 1.8, HTML4, or required support for IE11.
 2.0.0
 ~~~~~
 
-:Planned release date: 2022 Q1
+:Planned release date: 2023 Q3
 
-This release will mark the beginning of a new round of feature development, as
-well as a number of backward incompatible changes and deprecations.
+This release will drop support for old Python and Sphinx versions.
 
-Of note, the following backwards incompatible changes are planned for this
+Note the following backwards incompatible changes are planned for this
 release:
 
-Sphinx 1.x, Sphinx 2.x, and Docutils 0.16 will not be tested
+Python < 3.8, Sphinx <5 and Docutils < 0.18 will not be tested
     Official support will drop for these version, though they may still continue
     to work. Theme developers will not be testing these versions any longer.
-
-HTML4 support will be removed
-    Starting with this release, we will only support the HTML5 writer output,
-    and builds attempting to use the HTML4 writer will fail. If you are still
-    using the HTML4 writer, or have the ``html4_writer = True`` option in your
-    Sphinx configuration file, you will need to either remove this option or pin
-    your dependency to ``sphinx_rtd_theme<=2.0.0`` until you can.
-
-    This option was suggested in the past to work around issues with HTML5
-    support and should no longer be required to use a modern combination of this
-    theme and Sphinx.
 
 .. _roadmap-release-3.0.0:
 
 3.0.0
 ~~~~~
 
-This release is not yet planned, however there are plans to potentially replace
-Wyrm with Bootstrap in a release after 2.0.
+:Planned release date: 2024 Q1
+
+This release is not yet fully planned.
+However, we already know that HTML4 support will be dropped.
+
+HTML4 support will be removed
+    Starting with this release, we will only support the HTML5 writer output,
+    and builds attempting to use the HTML4 writer will fail. If you are still
+    using the HTML4 writer, or have the ``html4_writer = True`` option in your
+    Sphinx configuration file, you will need to either remove this option or pin
+    your dependency to ``sphinx_rtd_theme<=3`` until you can.
+
+    This option was suggested in the past to work around issues with HTML5
+    support and should no longer be required to use a modern combination of this
+    theme and Sphinx.
+
+4.0.0
+~~~~~
+
+This release is not yet planned.
+There are plans to potentially replace Wyrm with Bootstrap in a release after 3.0.
 
 Also tentatively planned for this release is finally removing built CSS and
 JavaScript assets from our repository. This will remove the ability to install

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -62,11 +62,20 @@ The theme officially supports the following dependencies in your Sphinx project:
     * - Dependency
       - Versions
     * - Python
-      - 2.7 or 3.6 or greater
+      - 3.6 or greater
     * - Sphinx
-      - 1.7 up to at least 4.1
+      - 5 or greater
     * - docutils
-      - Up to 0.17
+      - >= 0.14, < 0.19
+
+.. deprecated:: 2.0
+    Sphinx < 5 support removed
+
+.. deprecated:: 2.0
+    Python < 3.6 support removed
+
+.. deprecated:: 2.0
+    docutils < 0.14 support removed
 
 .. versionadded:: 1.0
     Sphinx 4.0 support added
@@ -150,7 +159,7 @@ This release will drop support for old Python and Sphinx versions.
 Note the following backwards incompatible changes are planned for this
 release:
 
-Python < 3.8, Sphinx <5 and Docutils < 0.18 will not be tested
+Python < 3.6, Sphinx < 5 and Docutils < 0.14 will not be tested
     Official support will drop for these version, though they may still continue
     to work. Theme developers will not be testing these versions any longer.
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -42,7 +42,7 @@ Internet Explorer (any OS, versions <=10)
 
 Internet Explorer (any OS, version 11)
     We currently only partially support IE11, and only test for major bugs.
-    Support will be removed in the :ref:`roadmap-release-2.0.0` release.
+    Support will be removed in the :ref:`roadmap-release-3.0.0` release.
 
 Opera (any OS, any version)
     **Community support only.** We do not receive enough traffic with this
@@ -171,7 +171,16 @@ Python < 3.6, Sphinx < 5 and Docutils < 0.14 will not be tested
 :Planned release date: 2024 Q1
 
 This release is not yet fully planned.
-However, we already know that HTML4 support will be dropped.
+However, we already know that we will be dropping support for older version of different dependencies and browsers.
+
+Sphinx 5, Python < 3.8 and docutils < 0.18 support will be removed
+    Sphinx 5 is the latest version that supports Python 3.6 and 3.7,
+    and docutils < 0.18.
+
+Internet Explorer 11 support will be dropped
+    `IE11 reached end of life on 14 June 20222 <https://endoflife.date/internet-explorer>`_,
+    so we are not supporting it on newer versions,
+    starting on 3.0.0.
 
 HTML4 support will be removed
     Starting with this release, we will only support the HTML5 writer output,
@@ -184,8 +193,12 @@ HTML4 support will be removed
     support and should no longer be required to use a modern combination of this
     theme and Sphinx.
 
+.. _roadmap-release-4.0.0:
+
 4.0.0
 ~~~~~
+
+:Planned release date: 2024 Q2
 
 This release is not yet planned.
 There are plans to potentially replace Wyrm with Bootstrap in a release after 3.0.
@@ -193,4 +206,4 @@ There are plans to potentially replace Wyrm with Bootstrap in a release after 3.
 Also tentatively planned for this release is finally removing built CSS and
 JavaScript assets from our repository. This will remove the ability to install
 the package directly from GitHub, and instead users will be advised to install
-development releases from PyPI
+development releases from PyPI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ project_urls =
 	Homepage = https://sphinx-rtd-theme.readthedocs.io/
 	Source Code = https://github.com/readthedocs/sphinx_rtd_theme
 	Issue Tracker = https://github.com/readthedocs/sphinx_rtd_theme/issues
-classifiers = 
+classifiers =
 	Framework :: Sphinx
 	Framework :: Sphinx :: Theme
 	Development Status :: 5 - Production/Stable
@@ -27,10 +27,7 @@ classifiers =
 	Environment :: Console
 	Environment :: Web Environment
 	Intended Audience :: Developers
-	Programming Language :: Python :: 2.7
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.6
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
@@ -43,9 +40,9 @@ classifiers =
 include_package_data = True
 zip_safe = False
 packages = sphinx_rtd_theme
-python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*
+python_requires = >=3.8
 install_requires = 
-	sphinx >=1.6,<8
+	sphinx >=5,<8
 	docutils <0.19
 	sphinxcontrib-jquery >=4,<5
 tests_require = 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,9 @@ classifiers =
 	Environment :: Web Environment
 	Intended Audience :: Developers
 	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3 :: Only
+	Programming Language :: Python :: 3.6
+	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
@@ -40,7 +43,7 @@ classifiers =
 include_package_data = True
 zip_safe = False
 packages = sphinx_rtd_theme
-python_requires = >=3.8
+python_requires = >=3.6
 install_requires = 
 	sphinx >=5,<8
 	docutils <0.19

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 envlist =
-    py{38,39,310}-sphinx{50,51,52,53,60,61}{-html4,-html5,}
+    py{36,37,38,39,310}-sphinx{50,51,52,53}{-html4,-html5,}
+    py{38,39,310}-sphinx{60,61}{-html4,-html5,}
     # HTML4 is not support on Sphinx >=7.x
-    py{38,39,310}-sphinx{70,71,latest}{-html5,}
+    py{38,39,310}-sphinx{70,71,72,latest}{-html5,}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,70,71,latest}{html5}
+    py{311}-sphinx{53,60,61,70,71,72,latest}{html5}
 
 [testenv]
 setenv =
@@ -21,6 +22,7 @@ deps =
     sphinx61: Sphinx>=6.1,<6.2
     sphinx70: Sphinx>=7.0,<7.1
     sphinx71: Sphinx>=7.1,<7.2
+    sphinx72: Sphinx>=7.2,<7.3
     sphinxlatest: Sphinx
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-sphinx{50,51,52,53}{-html4,-html5,}
-    py{38,39,310}-sphinx{60,61,62}{-html4,-html5,}
+    py{36,37,38,39,310}-sphinx{50,51,52,53}{-html4,-html5}
+    py{38,39,310}-sphinx{60,61,62}{-html4,-html5}
     # HTML4 is not support on Sphinx >=7.x
-    py{38,39,310}-sphinx{70,71,72,latest}{-html5,}
+    py{38,39,310}-sphinx{70,71,72,latest}{-html5}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,62,70,71,72,latest}{html5}
+    py{311}-sphinx{53,60,61,62,70,71,72,latest,sphinxdev}{-html5}
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
 envlist =
-    # Python 2.7 support was removed in Sphinx 2
-    py{27}-sphinx{17,18}{-html4,-html5,}{-qa,}
-    py{36,37,38,39}-sphinx{18,20,21,22,23,24,30,31,32,33,34,35,40,41,42,43,44,45,50,51,52}{-html4,-html5,}{-qa,}
-    # Python 3.10 working from Sphinx 4.2 and up
-    py{310}-sphinx{42,43,44,45,50,51,52,53,latest}{-html4,-html5}{-qa,}
-    # Sphinx 6+ has simplified docutils and Python support
-    py{38,39,10}-sphinx{60,61,70,71}{-html5,}{-qa,}
+    py{38,39,310}-sphinx{50,51,52,53,60,61}{-html4,-html5,}
+    # HTML4 is not support on Sphinx >=7.x
+    py{38,39,310}-sphinx{70,71,latest}{-html5,}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,70,71,latest}{html5}{-qa,}
+    py{311}-sphinx{53,60,61,70,71,latest}{html5}
 
 [testenv]
 setenv =
@@ -17,25 +13,6 @@ deps =
     .
     readthedocs-sphinx-ext
     pytest
-    sphinx17: Sphinx>=1.7,<1.8
-    sphinx18: Sphinx>=1.8,<1.9
-    sphinx20: Sphinx>=2.0,<2.1
-    sphinx21: Sphinx>=2.1,<2.2
-    sphinx22: Sphinx>=2.2,<2.3
-    sphinx23: Sphinx>=2.3,<2.4
-    sphinx24: Sphinx>=2.4,<2.5
-    sphinx30: Sphinx>=3.0,<3.1
-    sphinx31: Sphinx>=3.1,<3.2
-    sphinx32: Sphinx>=3.2,<3.3
-    sphinx33: Sphinx>=3.3,<3.4
-    sphinx34: Sphinx>=3.4,<3.5
-    sphinx35: Sphinx>=3.5,<3.6
-    sphinx40: Sphinx>=4.0,<4.1
-    sphinx41: Sphinx>=4.1,<4.2
-    sphinx42: Sphinx>=4.2,<4.3
-    sphinx43: Sphinx>=4.3,<4.4
-    sphinx44: Sphinx>=4.4,<4.5
-    sphinx45: Sphinx>=4.5,<4.6
     sphinx50: Sphinx>=5.0,<5.1
     sphinx51: Sphinx>=5.1,<5.2
     sphinx52: Sphinx>=5.2,<5.3
@@ -44,14 +21,6 @@ deps =
     sphinx61: Sphinx>=6.1,<6.2
     sphinx70: Sphinx>=7.0,<7.1
     sphinx71: Sphinx>=7.1,<7.2
-    # All these Sphinx versions actually break since docutils 0.18, so we need to add this upper bound
-    # Projects using these Sphinx versions will have to do the same
-    # See: https://github.com/readthedocs/sphinx_rtd_theme/pull/1304
-    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40,41,42}: docutils<0.18
-    # External environments are required to add this dependency for older versions of Sphinx
-    # because it didn't ship with this upper bound.
-    # See: https://github.com/sphinx-doc/sphinx/issues/10291
-    sphinx{17,18,20,21,22,23,24,30,31,32,33,34,35,40}: Jinja2<3.1
     sphinxlatest: Sphinx
     sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
 envlist =
     py{36,37,38,39,310}-sphinx{50,51,52,53}{-html4,-html5,}
-    py{38,39,310}-sphinx{60,61}{-html4,-html5,}
+    py{38,39,310}-sphinx{60,61,62}{-html4,-html5,}
     # HTML4 is not support on Sphinx >=7.x
     py{38,39,310}-sphinx{70,71,72,latest}{-html5,}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,70,71,72,latest}{html5}
+    py{311}-sphinx{53,60,61,62,70,71,72,latest}{html5}
 
 [testenv]
 setenv =
@@ -20,6 +20,7 @@ deps =
     sphinx53: Sphinx>=5.3,<5.4
     sphinx60: Sphinx>=6.0,<6.1
     sphinx61: Sphinx>=6.1,<6.2
+    sphinx62: Sphinx>=6.2,<6.3
     sphinx70: Sphinx>=7.0,<7.1
     sphinx71: Sphinx>=7.1,<7.2
     sphinx72: Sphinx>=7.2,<7.3


### PR DESCRIPTION
The new policy is:

- Python >=3.6
- Sphinx >= 5
- HTML4 and HTML5 writer
- docutils >= 0.14, < 0.19

Related: https://github.com/readthedocs/sphinx_rtd_theme/issues/1493