### PR TITLE
Use `.filename` attribute for CSS and JS files for `pathto`

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -32,12 +32,12 @@
     {%- if css|attr("rel") %}
       <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
     {%- else %}
-      <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
+      <link rel="stylesheet" href="{{ pathto(css.filename, 1) }}" type="text/css" />
     {%- endif %}
   {%- endfor %}
 
   {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+    <link rel="stylesheet" href="{{ pathto(cssfile.filename, 1) }}" type="text/css" />
   {%- endfor -%}
 
   {#- FAVICON
@@ -86,7 +86,7 @@
           };
       </script>
       {%- for scriptfile in script_files %}
-        <script src="{{ pathto(scriptfile, 1) }}"></script>
+        <script src="{{ pathto(scriptfile.filename, 1) }}"></script>
       {%- endfor %}
     {%- endif %}
     <script src="{{ pathto('_static/js/theme.js', 1) }}"></script>


### PR DESCRIPTION
Sphinx 7.2 changed how it handles the CSS and JS files internally and they cannot be treated as string anymore. We need to access to their `.filename` attribute to get the same behavior.

Closes #1502