### PR TITLE
Pass `includehidden=` as string instead of boolean

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -167,7 +167,7 @@
           {%- block menu %}
             {%- set toctree = toctree(maxdepth=theme_navigation_depth|int,
                                       collapse=theme_collapse_navigation|tobool,
-                                      includehidden=theme_includehidden|tobool,
+                                      includehidden=theme_includehidden,
                                       titles_only=theme_titles_only|tobool) %}
             {%- if toctree %}
               {{ toctree }}


### PR DESCRIPTION
Sphinx 7.2 changed its internal API for `toctree()`.

See https://github.com/sphinx-doc/sphinx/issues/11607 Related https://github.com/readthedocs/sphinx_rtd_theme/issues/1463