### PR TITLE
Visual test with Firefox and tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,15 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-sphinx{50,51,52,53}{-qa}
-    py{38,39,310}-sphinx{60,61,62,70,71}{-qa}
-    py{39,310}-sphinx{72,latest,dev}{-qa}
+    py{36,37,38,39,310}-sphinx{50,51,52,53}{-qa}{-firefox}
+    py{38,39,310}-sphinx{60,61,62,70,71}{-qa}{-firefox}
+    py{39,310}-sphinx{72,latest,dev}{-qa}{-firefox}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,62,70,71,72,latest,dev}{-qa}
+    py{311}-sphinx{53,60,61,62,70,71,72,latest,dev}{-qa}{-firefox}
 
 [testenv]
 setenv =
     LANG=C
+    DISPLAY={env:DISPLAY}
 deps =
     .
     readthedocs-sphinx-ext
@@ -25,6 +26,10 @@ deps =
     sphinx72: Sphinx>=7.2,<7.3
     sphinxlatest: Sphinx
     dev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
+allowlist_externals =
+    firefox
+    sh
 commands =
     pytest {posargs} tests/
     sphinx-build -b html -Dhtml4_writer=0 -d {envtmpdir}/doctrees docs/ {envtmpdir}/html
+    firefox: sh -c 'firefox -P sphinx-theme-testing "{envtmpdir}/html/demo/demo.html" &'

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist =
 [testenv]
 setenv =
     LANG=C
-    DISPLAY={env:DISPLAY}
+    DISPLAY={env:DISPLAY::0.0}
 deps =
     .
     readthedocs-sphinx-ext
@@ -32,4 +32,4 @@ allowlist_externals =
 commands =
     pytest {posargs} tests/
     sphinx-build -b html -Dhtml4_writer=0 -d {envtmpdir}/doctrees docs/ {envtmpdir}/html
-    firefox: sh -c 'firefox -P sphinx-theme-testing "{envtmpdir}/html/demo/demo.html" &'
+    firefox: sh -c 'firefox -P sphinx-theme-testing --new-tab "{envtmpdir}/html/demo/demo.html" &'

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,14 @@
 [tox]
 envlist =
-    py{36,37,38,39,310}-sphinx{50,51,52,53}{-qa}{-firefox}
-    py{38,39,310}-sphinx{60,61,62,70,71}{-qa}{-firefox}
-    py{39,310}-sphinx{72,latest,dev}{-qa}{-firefox}
+    py{36,37,38,39,310}-sphinx{50,51,52,53}{-qa}
+    py{38,39,310}-sphinx{60,61,62,70,71}{-qa}
+    py{39,310}-sphinx{72,latest,dev}{-qa}
     # Python 3.11 working from Sphinx 5.3 and up
-    py{311}-sphinx{53,60,61,62,70,71,72,latest,dev}{-qa}{-firefox}
+    py{311}-sphinx{53,60,61,62,70,71,72,latest,dev}{-qa}
 
 [testenv]
 setenv =
     LANG=C
-    DISPLAY={env:DISPLAY::0.0}
 deps =
     .
     readthedocs-sphinx-ext
@@ -27,9 +26,8 @@ deps =
     sphinxlatest: Sphinx
     dev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 allowlist_externals =
-    firefox
-    sh
+    echo
 commands =
     pytest {posargs} tests/
     sphinx-build -b html -Dhtml4_writer=0 -d {envtmpdir}/doctrees docs/ {envtmpdir}/html
-    firefox: sh -c 'firefox -P sphinx-theme-testing --new-tab "{envtmpdir}/html/demo/demo.html" &'
+    echo "Open the following URL for visual testing: file://{envtmpdir}/html/demo/demo.html"


### PR DESCRIPTION
Allows developer to run

```
tox -e py310-sphinx72
```

This will run the tests and open a Firefox after building the demo site showing the `demo/demo.html` page on it.

Then, you can also run:

```
tox -e py310-sphinx61
```

and compare the visual differences by opening the URL shown in the terminal:

```
The HTML pages are in .tox/py310-sphinx61/tmp/html.
py310-sphinx61: commands[2]> echo 'Open the following URL for visual testing: file:///home/humitos/rtfd/code/sphinx_rtd_theme/.tox/py310-sphinx61/tmp/html/demo/demo.html'
Open the following URL for visual testing: file:///home/humitos/rtfd/code/sphinx_rtd_theme/.tox/py310-sphinx61/tmp/html/demo/demo.html
```

Idea copied from #1388
Closes #1388