### PR TITLE
Remove pytest warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+filterwarnings =
+    # Ignore external dependencies warning deprecations
+    # Sphinx
+    ignore::sphinx.deprecation.RemovedInSphinx90Warning

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -18,7 +18,7 @@ from .util import build_all
 
 def test_basic():
     for (app, status, warning) in build_all('test-basic'):
-        assert app.env.get_doctree('index').traverse(addnodes.toctree)
+        assert app.env.get_doctree('index').findall(addnodes.toctree)
         content = open(os.path.join(app.outdir, 'index.html')).read()
 
         if isinstance(app.builder, DirectoryHTMLBuilder):
@@ -66,7 +66,7 @@ def test_basic():
 def test_empty():
     """Local TOC is showing, as toctree was empty"""
     for (app, status, warning) in build_all('test-empty'):
-        assert app.env.get_doctree('index').traverse(addnodes.toctree)
+        assert app.env.get_doctree('index').findall(addnodes.toctree)
         content = open(os.path.join(app.outdir, 'index.html')).read()
         global_toc = '<div class="toctree-wrapper compound">\n</div>'
         local_toc = (
@@ -81,7 +81,7 @@ def test_empty():
 def test_missing_toctree():
     """Local TOC is showing, as toctree was missing"""
     for (app, status, warning) in build_all('test-missing-toctree'):
-        assert app.env.get_doctree('index').traverse(addnodes.toctree) == []
+        assert list(app.env.get_doctree('index').findall(addnodes.toctree)) == []
         content = open(os.path.join(app.outdir, 'index.html')).read()
         assert '<div class="toctree' not in content
         assert '<div class="local-toc">' in content


### PR DESCRIPTION
Ignore deprecations on Sphinx 9.0 that comes from readthedocs-sphinx-ext and use `findall()` instead of `.traverse()` as suggested by docutils.

Closes #1142 