### PR TITLE
Use `css_tag` helper to inject CSS files

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -33,7 +33,7 @@
   {%- endfor %}
 
   {%- for cssfile in extra_css_files %}
-    {{ css_tag(css) }}
+    {{ css_tag(cssfile) }}
   {%- endfor -%}
 
   {#- FAVICON

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -29,15 +29,11 @@
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- endif %}
   {%- for css in css_files %}
-    {%- if css|attr("rel") %}
-      <link rel="{{ css.rel }}" href="{{ pathto(css.filename, 1) }}" type="text/css"{% if css.title is not none %} title="{{ css.title }}"{% endif %} />
-    {%- else %}
-      <link rel="stylesheet" href="{{ pathto(css, 1) }}" type="text/css" />
-    {%- endif %}
+    {{ css_tag(css) }}
   {%- endfor %}
 
   {%- for cssfile in extra_css_files %}
-    <link rel="stylesheet" href="{{ pathto(cssfile, 1) }}" type="text/css" />
+    {{ css_tag(css) }}
   {%- endfor -%}
 
   {#- FAVICON


### PR DESCRIPTION
Split #1512 to apply only the CSS/JS tag changes that are required to support Sphinx >= 7.2 (see https://github.com/readthedocs/sphinx_rtd_theme/pull/1512#pullrequestreview-1599313399)

> If we need any of these changes specifically for Sphinx 7 support, they can be broken away from some of the cleanup changes here

* Closes #1101
* Closes #1503