### PR TITLE
Fix AttributeError when one of `css_files` is a string

### DIFF
--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -29,7 +29,11 @@
     <link rel="stylesheet" href="{{ pathto('_static/pygments.css', 1) }}" type="text/css" />
   {%- endif %}
   {%- for css_file in css_files %}
-    {{ css_tag(css_file) }}
+    {%- if css_file|attr("filename") %}
+      {{ css_tag(css_file) }}
+    {%- else %}
+      <link rel="stylesheet" href="{{ pathto(css_file, 1)|escape }}" type="text/css" />
+    {%- endif %}
   {%- endfor %}
 
   {# "extra_css_files" is a theme option and it's always a string #}


### PR DESCRIPTION
Unfortunately, the last version of #1528 still did not work properly in some cases.

When `css_files` comes from Sphinx, every item of this list is an instance of `_CascadingStyleSheet` class, and `css_tag` works with it.

However, some projects override `css_files` in their templates:
- https://github.com/laspy/laspy/blob/2.5.1/docs/_templates/layout.html

or pass `css_files` to HTML context explicitly from `conf.py`:
- https://review.coreboot.org/plugins/gitiles/coreboot/+/refs/tags/4.20.1/Documentation/conf.py#91
- https://github.com/isl-org/Open3D/blob/v0.17.0/docs/conf.in.py#L160

To make build of these projects succeed, we need to support `css_file` being a string.
Here I copied the logic from [Sphinx itself](https://github.com/sphinx-doc/sphinx/blob/v7.2.6/sphinx/themes/basic/layout.html#L94-L98).

See [this Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1054685) for the logs of the failed builds.