### PR TITLE
Tests: `sphinxdev` tox environment installs Sphinx from `master`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ deps =
     sphinx71: Sphinx>=7.1,<7.2
     sphinx72: Sphinx>=7.2,<7.3
     sphinxlatest: Sphinx
-    dev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
+    sphinxdev: https://github.com/sphinx-doc/sphinx/archive/refs/heads/master.zip
 allowlist_externals =
     echo
 commands =


### PR DESCRIPTION
It seems we had a bug in the name and it wasn't installing Sphinx from `master`. I expect this test to fail now because we pin `Sphinx<8`, but that's fine for now.