### PR TITLE
Theme option `flyout` to enable/disable theme's flyout

### DIFF
--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -179,6 +179,8 @@ Miscellaneous options
 
     Specify how to display the flyout (language and version selector).
     This can be either ``attached`` or ``hidden``.
+    ``attached`` means that it will show the flyout in the bottom of the sidebar.
+    You will need to disable the default `Read the Docs flyout <https://docs.readthedocs.io/en/stable/flyout-menu.html>`_ in order to not have 2 flyouts showing.
 
     :type: str
     :default: ``hidden``

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -21,7 +21,7 @@ For example:
         'style_external_links': False,
         'vcs_pageview_mode': '',
         'style_nav_header_background': 'white',
-        'flyout_display': 'attached',
+        'flyout_display': 'hidden',
         # Toc options
         'collapse_navigation': True,
         'sticky_navigation': True,
@@ -181,7 +181,7 @@ Miscellaneous options
     This can be either ``attached`` or ``hidden``.
 
     :type: str
-    :default: ``attached``
+    :default: ``hidden``
 
 
 File-wide metadata

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -21,7 +21,7 @@ For example:
         'style_external_links': False,
         'vcs_pageview_mode': '',
         'style_nav_header_background': 'white',
-        'flyout': False,
+        'flyout_display': 'attached',
         # Toc options
         'collapse_navigation': True,
         'sticky_navigation': True,
@@ -175,13 +175,13 @@ Miscellaneous options
     :type: string
     :default: ``#2980B9``
 
-.. confval:: flyout
+.. confval:: flyout_display
 
-    Render the flyout (language and version selector) at the bottom left
-    integrated in the navigation bar.
+    Specify how to display the flyout (language and version selector).
+    This can be either ``attached`` or ``hidden``.
 
-    :type: boolean
-    :default: ``True``
+    :type: str
+    :default: ``attached``
 
 
 File-wide metadata

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -21,6 +21,7 @@ For example:
         'style_external_links': False,
         'vcs_pageview_mode': '',
         'style_nav_header_background': 'white',
+        'flyout': False,
         # Toc options
         'collapse_navigation': True,
         'sticky_navigation': True,
@@ -173,6 +174,14 @@ Miscellaneous options
 
     :type: string
     :default: ``#2980B9``
+
+.. confval:: flyout
+
+    Render the flyout (language and version selector) at the bottom left
+    integrated in the navigation bar.
+
+    :type: boolean
+    :default: ``True``
 
 
 File-wide metadata

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -67,7 +67,7 @@
     {%- endfor %}
     <script src="{{ pathto('_static/js/theme.js', 1) }}"></script>
 
-    {%- if READTHEDOCS and theme_flyout %}
+    {%- if READTHEDOCS and theme_flyout_display != "hidden" %}
     <script src="{{ pathto('_static/js/versions.js', 1) }}"></script>
     {%- endif %}
 

--- a/sphinx_rtd_theme/layout.html
+++ b/sphinx_rtd_theme/layout.html
@@ -67,7 +67,7 @@
     {%- endfor %}
     <script src="{{ pathto('_static/js/theme.js', 1) }}"></script>
 
-    {%- if READTHEDOCS %}
+    {%- if READTHEDOCS and theme_flyout %}
     <script src="{{ pathto('_static/js/versions.js', 1) }}"></script>
     {%- endif %}
 

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -18,4 +18,4 @@ prev_next_buttons_location = bottom
 style_external_links = False
 style_nav_header_background =
 vcs_pageview_mode =
-flyout = True
+flyout_display = attached

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -18,4 +18,4 @@ prev_next_buttons_location = bottom
 style_external_links = False
 style_nav_header_background =
 vcs_pageview_mode =
-flyout_display = attached
+flyout_display = hidden

--- a/sphinx_rtd_theme/theme.conf
+++ b/sphinx_rtd_theme/theme.conf
@@ -18,3 +18,4 @@ prev_next_buttons_location = bottom
 style_external_links = False
 style_nav_header_background =
 vcs_pageview_mode =
+flyout = True


### PR DESCRIPTION
Add a theme option to enable/disable the theme's flyout integrated at the bottom left into the navigation bar.

Closes #1579