### PR TITLE
Populate `html_context` with `READTHEDOCS_*` environment variables

### DIFF
--- a/sphinx_rtd_theme/__init__.py
+++ b/sphinx_rtd_theme/__init__.py
@@ -41,7 +41,7 @@ def extend_html_context(app, pagename, templatename, context, doctree):
      # https://docs.readthedocs.io/en/stable/reference/environment-variables.html
      context['READTHEDOCS'] = os.environ.get("READTHEDOCS", False) == "True"
      if context['READTHEDOCS']:
-         for key, value in os.environ:
+         for key, value in os.environ.items():
              if key.startswith("READTHEDOCS_"):
                  context[key] = value
 


### PR DESCRIPTION
Closes #1578
Related: https://github.com/readthedocs/readthedocs.org/issues/11474