### PR TITLE
Support Sphinx 8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ zip_safe = False
 packages = sphinx_rtd_theme
 python_requires = >=3.6
 install_requires = 
-	sphinx >=5,<8
+	sphinx >=5,<9
 	docutils <0.21
 	sphinxcontrib-jquery >=4,<5
 tests_require = 


### PR DESCRIPTION
Read the Docs Sphinx Theme should work with Sphinx 8 unchanged. From https://github.com/sphinx-doc/sphinx/issues/12629:
> This release would be only removing expired deprecations, dropping support for Python 3.9, and consequent refactorings -- I wouldn't expect any new features to be included.

#1576 already includes tests for Sphinx 8 and Python>=3.10: 7a6b1a6566545b53e98d2f09c285f08b055c9558. It can be cherry-picked onto this PR if required.

Closes #1582
Is a pre-requisite for #1559 listed in #1576.
Despite being [suggested](https://github.com/readthedocs/sphinx_rtd_theme/pull/1576#issuecomment-2260650071) #1571 does not have a problem with it, because #1571 was fixed in 2.0.0.
