### PR TITLE
Docs: update the installation note

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -31,15 +31,13 @@ In your Sphinx project's ``conf.py`` file, add ``sphinx_rtd_theme`` to the list 
 
 .. note::
 
-   Adding this theme as an extension is what enables localization of theme
-   strings in your translated output. If these strings are not translated in
-   your output, either we lack the localized strings for your locale, or you
-   are using an old version of the theme.
+   Adding this theme as an extension is what enables ``sphinxcontrib-jquery`` extension
+   to get properly configured which is required for search, smooth scroll and open/close the flyout.
+   If any of these feature doesn't work, make sure you have the theme declared in your ``extensions``.
 
-   ..
-      comment about this note: it's possibly not necessary to add the theme as an extension.
-      Rather, this is an issue caused by setting html_theme_path.
-      See: https://github.com/readthedocs/readthedocs.org/pull/9654
+   .. More context for this note:
+        * https://github.com/readthedocs/sphinx_rtd_theme/issues/1434#issuecomment-2288359582
+        * https://github.com/readthedocs/sphinx_rtd_theme/issues/1222#issuecomment-2296703160
 
 
 .. _howto_upgrade:

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -31,9 +31,9 @@ In your Sphinx project's ``conf.py`` file, add ``sphinx_rtd_theme`` to the list 
 
 .. note::
 
-   Adding this theme as an extension is what enables ``sphinxcontrib-jquery`` extension
-   to get properly configured which is required for search, smooth scroll and open/close the flyout.
-   If any of these feature doesn't work, make sure you have the theme declared in your ``extensions``.
+   Adding this theme as an extension activates the ``sphinxcontrib-jquery`` extension,
+   which is required for search, smooth scrolling, and the flyout menu.
+   If any of these features don't work, make sure you have the theme declared in your ``extensions``.
 
    .. More context for this note:
         * https://github.com/readthedocs/sphinx_rtd_theme/issues/1434#issuecomment-2288359582


### PR DESCRIPTION
Translated string work with/without the theme added into the ``extensions``. However, it's still required to be inside the extensions because of ``sphinxcontrib-jquery``.

I'm keeping the note, but changing it content.

- Refs https://github.com/readthedocs/sphinx_rtd_theme/issues/1222