### PR TITLE
Trigger search modal on "Search docs" input focus

### DIFF
--- a/sphinx_rtd_theme/static/js/versions.js_t
+++ b/sphinx_rtd_theme/static/js/versions.js_t
@@ -132,15 +132,7 @@ if (themeFlyoutDisplay === "attached") {
         const event = new CustomEvent("readthedocs-search-show");
         document.dispatchEvent(event);
       });
-
-    // Trigger the Read the Docs Addons Search modal when clicking on "Search docs" input from the topnav.
-    document
-      .querySelector("[role='search'] input")
-      .addEventListener("focusin", () => {
-        const event = new CustomEvent("readthedocs-search-show");
-        document.dispatchEvent(event);
-      });
-  });
+  })
 }
 
 if (themeLanguageSelector || themeVersionSelector) {
@@ -220,3 +212,13 @@ if (themeLanguageSelector || themeVersionSelector) {
     }
   });
 }
+
+document.addEventListener("readthedocs-addons-data-ready", function (event) {
+  // Trigger the Read the Docs Addons Search modal when clicking on "Search docs" input from the topnav.
+  document
+    .querySelector("[role='search'] input")
+    .addEventListener("focusin", () => {
+      const event = new CustomEvent("readthedocs-search-show");
+      document.dispatchEvent(event);
+    });
+});


### PR DESCRIPTION
This is a regression introduced in
https://github.com/readthedocs/sphinx_rtd_theme/pull/1601

This PR triggers the search modal when clicking on the "Search docs" input from
- inside the flyout if present
- the top left navbar