### PR TITLE
docs/contributing.rst: Fix typo

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -227,7 +227,7 @@ Releasing the theme
 
 To release a new version of the theme, core team will take the following steps:
 
-#. Install the required depedencies with ``pip install '.[dev]'``.
+#. Install the required dependencies with ``pip install '.[dev]'``.
 #. Bump the version by running ``bump2version [major|minor|patch|dev]``.
    This will automatically increase the correct part(s) of the version number,
    you do not need to specify the exact version number.


### PR DESCRIPTION
```diff
- #. Install the required depedencies with ``pip install '.[dev]'``.
+ #. Install the required dependencies with ``pip install '.[dev]'``.
```