### PR TITLE
Allow disabling selectors

### DIFF
--- a/sphinx_rtd_theme/static/js/versions.js_t
+++ b/sphinx_rtd_theme/static/js/versions.js_t
@@ -1,6 +1,6 @@
 const themeFlyoutDisplay = "{{ theme_flyout_display }}";
-const themeVersionSelector = "{{ theme_version_selector }}";
-const themeLanguageSelector = "{{ theme_language_selector }}";
+const themeVersionSelector = {{ 'true' if theme_version_selector|tobool else 'false' }};
+const themeLanguageSelector = {{ 'true' if theme_language_selector|tobool else 'false' }};
 
 if (themeFlyoutDisplay === "attached") {
   function renderLanguages(config) {


### PR DESCRIPTION
There was a bug with how we render a Python bool value into JavaScript. This PR fixes that issue.

Closes #1620