### PR TITLE
Harmonise README.rst and installing.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,9 +34,14 @@ This theme is distributed on PyPI_ and can be installed with ``pip``:
    $ pip install sphinx-rtd-theme
 
 To use the theme in your Sphinx project, you will need to edit
-your ``conf.py`` file's ``html_theme`` setting:
+your ``conf.py`` file's ``extensions`` and ``html_theme`` settings:
 
 .. code:: python
+
+    extensions = [
+        ...
+        "sphinx_rtd_theme",
+    ]
 
     html_theme = "sphinx_rtd_theme"
 


### PR DESCRIPTION
It's important to add the theme to `extensions` as well as setting `html_theme`, but README.rst doesn't currently mention the need to modify `extensions`.

see #1222