### PR TITLE
Persist URL location when switching versions

### DIFF
--- a/sphinx_rtd_theme/static/js/versions.js_t
+++ b/sphinx_rtd_theme/static/js/versions.js_t
@@ -40,7 +40,7 @@ if (themeFlyoutDisplay === "attached") {
           .map(
             (version) => `
         <dd ${version.slug === config.versions.current.slug ? 'class="rtd-current-item"' : ""}>
-          <a href="${version.urls.documentation}">${version.slug}</a>
+          <a href="${window.location.pathname.replace(config.versions.current.slug, version.slug)}">${version.slug}</a>
         </dd>
         `,
           )


### PR DESCRIPTION
When switching versions (e.g. between `stable` and `latest`) it is useful to keep the current page/URL as discussed in https://github.com/readthedocs/sphinx_rtd_theme/issues/1638.

It looks like there will be an overhaul of the JS in https://github.com/readthedocs/sphinx_rtd_theme/pull/1637 but until then this update solves the issue (and is deployed as an override in the [GDAL docs](https://github.com/OSGeo/gdal/pull/13480). 

The fix is based on https://github.com/jasmin-lang/jasmin/pull/1287 by @eponier. 
