### PR TITLE
Avoid duplicate prev/next access keys

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -66,10 +66,10 @@
   {#- Translators: This is an ARIA section label for sequential page links, such as previous and next page links. -#}
   <div class="rst-breadcrumbs-buttons" role="navigation" aria-label="{{ _('Sequential page navigation') }}">
       {%- if prev %}
-        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}" accesskey="p"><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
+        <a href="{{ prev.link|e }}" class="btn btn-neutral float-left" title="{{ prev.title|striptags|e }}"{% if theme_prev_next_buttons_location == 'top' %} accesskey="p"{% endif %}><span class="fa fa-arrow-circle-left" aria-hidden="true"></span> {{ _('Previous') }}</a>
       {%- endif %}
       {%- if next %}
-        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}" accesskey="n">{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
+        <a href="{{ next.link|e }}" class="btn btn-neutral float-right" title="{{ next.title|striptags|e }}"{% if theme_prev_next_buttons_location == 'top' %} accesskey="n"{% endif %}>{{ _('Next') }} <span class="fa fa-arrow-circle-right" aria-hidden="true"></span></a>
       {%- endif %}
   </div>
   {%- endif %}

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -13,7 +13,7 @@ except ImportError:
         SingleFileHTMLBuilder,
     )
 
-from .util import build_all
+from .util import build, build_all
 
 
 def test_basic():
@@ -88,3 +88,17 @@ def test_missing_toctree():
         content = open(os.path.join(app.outdir, 'index.html')).read()
         assert '<div class="toctree' not in content
         assert '<div class="local-toc">' in content
+
+
+def test_prev_next_accesskeys_are_unique_when_buttons_location_is_both():
+    confoverrides = {
+        'html_theme_options': {
+            'prev_next_buttons_location': 'both',
+        },
+    }
+
+    with build('test-basic', confoverrides=confoverrides) as (app, status, warning):
+        content = open(os.path.join(app.outdir, 'foo.html'), encoding='utf-8').read()
+
+    assert content.count('accesskey="p"') == 1
+    assert content.count('accesskey="n"') == 1


### PR DESCRIPTION
When prev/next buttons are shown in both locations, both the top and footer links currently render the same `accesskey` values. This keeps the access keys on the footer links and omits them from the duplicate top links when the location is `both`.

Checks:
- git diff --check
- uv run --with pytest --with sphinx --with-editable . pytest tests/test_builders.py::test_prev_next_accesskeys_are_unique_when_buttons_location_is_both
- PYTHONUTF8=1 uv run --with pytest --with sphinx --with-editable . pytest tests/test_builders.py

Fixes #1057
