### PR TITLE
Hide edit links on generated pages

### DIFF
--- a/sphinx_rtd_theme/breadcrumbs.html
+++ b/sphinx_rtd_theme/breadcrumbs.html
@@ -17,6 +17,7 @@
 {%- endif %}
 
 {%- set display_vcs_links = display_vcs_links if display_vcs_links is defined else True %}
+{%- set has_source_page = pagename not in ['genindex', 'search'] %}
 
 {#- Translators: This is an ARIA section label for page links, including previous/next page link and links to GitHub/GitLab/etc. -#}
 <div role="navigation" aria-label="{{ _('Page navigation') }}">
@@ -30,7 +31,7 @@
     {%- endblock %}
     {%- block breadcrumbs_aside %}
       <li class="wy-breadcrumbs-aside">
-        {%- if hasdoc(pagename) and display_vcs_links %}
+        {%- if hasdoc(pagename) and has_source_page and display_vcs_links %}
           {%- if display_github %}
             {%- if check_meta and 'github_url' in meta %}
               <!-- User defined GitHub URL -->

--- a/tests/test_builders.py
+++ b/tests/test_builders.py
@@ -13,7 +13,7 @@ except ImportError:
         SingleFileHTMLBuilder,
     )
 
-from .util import build_all
+from .util import build, build_all
 
 
 def test_basic():
@@ -64,6 +64,34 @@ def test_basic():
             )
             assert search in content, ('Missing search with builder {0}'
                                        .format(app.builder.name))
+
+
+def test_edit_links_are_skipped_for_generated_pages():
+    html_context = {
+        'display_github': True,
+        'github_user': 'readthedocs',
+        'github_repo': 'sphinx_rtd_theme',
+        'github_version': 'master/',
+        'conf_py_path': 'tests/roots/test-basic/',
+    }
+
+    with build('test-basic', confoverrides={'html_context': html_context}) as (
+        app,
+        _status,
+        _warning,
+    ):
+        content = open(
+            os.path.join(app.outdir, 'index.html'),
+            encoding='utf-8',
+        ).read()
+        assert 'Edit on GitHub' in content
+
+        for filename in ['genindex.html', 'search.html']:
+            content = open(
+                os.path.join(app.outdir, filename),
+                encoding='utf-8',
+            ).read()
+            assert 'Edit on GitHub' not in content
 
 
 def test_empty():


### PR DESCRIPTION
### Summary
- skip breadcrumbs edit links on generated pages (`genindex`, `search`)
- keep edit links on regular source pages
- add a regression test for the GitHub edit-link context

### Checks
- `uv run --with pytest --with Sphinx --with-editable . pytest tests/test_builders.py::test_edit_links_are_skipped_for_generated_pages`
- `PYTHONUTF8=1 uv run --with pytest --with Sphinx --with-editable . pytest tests/test_builders.py`
- `git diff --check`

Fixes #765.